### PR TITLE
Custom sni and host via XRAY_HOSTS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,12 +8,18 @@ XRAY_JSON = "xray.json"
 XRAY_EXECUTABLE_PATH = "/usr/local/bin/xray"
 XRAY_ASSETS_PATH = "/usr/local/share/xray"
 
-### XRAY_HOSTS must be remark@hostname of hosts
-### if XRAY_HOSTS isn't defined, server IP will be used automatically
-# XRAY_HOSTS = "
+### Each line of XRAY_HOSTS determines a host in one of the following formats:
+### - remark@address
+### - {"remark": "myremark", "address": "10.20.30.40", "sni": "mysni.example.com", "host": "myhost.example.com"}
+### If XRAY_HOSTS isn't defined, server IP will be used automatically as address.
+### You can have empty lines or comments in XRAY_HOSTS.
+# XRAY_HOSTS = '
 # Server@127.0.0.1
 # Bridge@192.168.1.10
-# "
+# John\'s Domain@john.example.com
+# # You can set custom sni and host using JSON format:
+# {"remark": "CDN2", "address": "10.20.30.40", "sni": "my.example2.com", "host": "my.example2.com"}
+# '
 
 # XRAY_SUBSCRIPTION_URL_PREFIX = "http://example.com"
 

--- a/README-fa.md
+++ b/README-fa.md
@@ -154,7 +154,7 @@ python3 main.py
 |                                                                               اجرای مرزبان بر روی یک Unix domain socket |           UVICORN_UDS           |
 |                                                                              آدرس گواهی SSL به جهت ایمن کردن پنل مرزبان |      UVICORN_SSL_CERTFILE       |
 |                                                                                                     آدرس کلید گواهی SSL |       UVICORN_SSL_KEYFILE       |
-|                              آدرس هاست های Xray هرکدام در یک خط. با فرمت `remark@hostname` (پیشفرض: `🚀 Marz@SERVER_IP`) |           XRAY_HOSTS            |
+|                              آدرس هاست های Xray هرکدام در یک خط. با فرمت `remark@address` یا `{"remark": "myremark", "address": "10.20.30.40", "sni": "mysni.example.com", "host": "myhost.example.com"}` (پیشفرض: `🚀 Marz@SERVER_IP`) |           XRAY_HOSTS            |
 |                                                                       مسیر فایل json تنظیمات xray (پیشفرض: `xray.json`) |            XRAY_JSON            |
 |                                                                        مسیر باینری xray (پیشفرض: `/usr/local/bin/xray`) |      XRAY_EXECUTABLE_PATH       |
 |                                                                   مسیر asset های xray (پیشفرض: `/usr/local/share/xray`) |        XRAY_ASSETS_PATH         |

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ By default the app will be run on `http://localhost:8000/dashboard`. You can con
 | UVICORN_UDS                     | Bind application to a UNIX domain socket                                                              |
 | UVICORN_SSL_CERTFILE            | SSL certificate file to have application on https                                                     |
 | UVICORN_SSL_KEYFILE             | SSL key file to have application on https                                                             |
-| XRAY_HOSTS                      | Xray hosts in different lines with `remark@hostname` format (default: `🚀 Marz@SERVER_IP`)             |
+| XRAY_HOSTS                      | Xray hosts in different lines with `remark@address` or `{"remark": "myremark", "address": "10.20.30.40", "sni": "mysni.example.com", "host": "myhost.example.com"}` format (default: `🚀 Marz@SERVER_IP`)             |
 | XRAY_JSON                       | Path of Xray's json config file (default: `xray.json`)                                                |
 | XRAY_EXECUTABLE_PATH            | Path of Xray binary (default: `/usr/local/bin/xray`)                                                  |
 | XRAY_ASSETS_PATH                | Path of Xray assets (default: `/usr/local/share/xray`)                                                |

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -115,9 +115,11 @@ class UserResponse(User):
             for host in XRAY_HOSTS:
                 for proxy_type, settings in values.get('proxies', {}).items():
                     link = ShareLink(f"{host['remark']} ({values['username']})",
-                                     host['hostname'],
+                                     host['address'],
                                      proxy_type,
-                                     settings.dict())
+                                     settings.dict(),
+                                     custom_sni=host['sni'],
+                                     custom_host=host['host'])
                     links.extend(link.split('\n'))
             return links
         return v

--- a/app/utils/share.py
+++ b/app/utils/share.py
@@ -11,19 +11,26 @@ from config import XRAY_HOSTS
 
 
 class ShareLink(str):
-    def __new__(cls, remark: str, host: str, protocol: str, settings: dict):
+    def __new__(cls,
+                remark: str,
+                address: str,
+                protocol: str,
+                settings: dict,
+                *,
+                custom_sni: str = "",
+                custom_host: str = ""):
         if protocol == 'vmess':
             links = []
             for i in INBOUNDS.get(protocol, []):
                 links.append(
                     cls.vmess(remark=remark,
-                              address=host,
+                              address=address,
                               port=i['port'],
                               id=settings['id'],
                               net=i['stream']['net'],
                               tls=i['stream']['tls'],
-                              sni=i['stream']['sni'],
-                              host=i['stream']['host'],
+                              sni=custom_sni or i['stream']['sni'],
+                              host=custom_host or i['stream']['host'],
                               path=i['stream']['path'],
                               type=i['stream']['header_type'])
                 )
@@ -34,13 +41,13 @@ class ShareLink(str):
             for i in INBOUNDS.get(protocol, []):
                 links.append(
                     cls.vless(remark=remark,
-                              address=host,
+                              address=address,
                               port=i['port'],
                               id=settings['id'],
                               net=i['stream']['net'],
                               tls=i['stream']['tls'],
-                              sni=i['stream']['sni'],
-                              host=i['stream']['host'],
+                              sni=custom_sni or i['stream']['sni'],
+                              host=custom_host or i['stream']['host'],
                               path=i['stream']['path'],
                               type=i['stream']['header_type'])
                 )
@@ -51,13 +58,13 @@ class ShareLink(str):
             for i in INBOUNDS.get(protocol, []):
                 links.append(
                     cls.trojan(remark=remark,
-                               address=host,
+                               address=address,
                                port=i['port'],
                                password=settings['password'],
                                net=i['stream']['net'],
                                tls=i['stream']['tls'],
-                               sni=i['stream']['sni'],
-                               host=i['stream']['host'],
+                               sni=custom_sni or i['stream']['sni'],
+                               host=custom_host or i['stream']['host'],
                                path=i['stream']['path'],
                                type=i['stream']['header_type'])
                 )
@@ -68,7 +75,7 @@ class ShareLink(str):
             for i in INBOUNDS.get(protocol, []):
                 links.append(
                     cls.shadowsocks(remark=remark,
-                                    address=host,
+                                    address=address,
                                     port=i['port'],
                                     password=settings['password'])
                 )
@@ -209,35 +216,42 @@ class ClashConfiguration(object):
                 return new
             c += 1
 
-    def add(self, remark: str, host: str, protocol: str, settings: dict):
+    def add(self,
+            remark: str,
+            address: str,
+            protocol: str,
+            settings: dict,
+            *,
+            custom_sni: str = "",
+            custom_host: str = ""):
         if protocol == 'vmess':
             for i in INBOUNDS.get(protocol, []):
                 self.add_vmess(remark=remark,
-                               address=host,
+                               address=address,
                                port=i['port'],
                                id=settings['id'],
                                net=i['stream']['net'],
                                tls=i['stream']['tls'],
-                               sni=i['stream']['sni'],
-                               host=i['stream']['host'],
+                               sni=custom_sni or i['stream']['sni'],
+                               host=custom_host or i['stream']['host'],
                                path=i['stream']['path'])
 
         if protocol == 'trojan':
             for i in INBOUNDS.get(protocol, []):
                 self.add_trojan(remark=remark,
-                                address=host,
+                                address=address,
                                 port=i['port'],
                                 password=settings['password'],
                                 net=i['stream']['net'],
                                 tls=i['stream']['tls'],
-                                sni=i['stream']['sni'],
-                                host=i['stream']['host'],
+                                sni=custom_sni or i['stream']['sni'],
+                                host=custom_host or i['stream']['host'],
                                 path=i['stream']['path'])
 
         if protocol == 'shadowsocks':
             for i in INBOUNDS.get(protocol, []):
                 self.add_shadowsocks(remark=remark,
-                                     address=host,
+                                     address=address,
                                      port=i['port'],
                                      password=settings['password'])
 
@@ -314,7 +328,12 @@ def get_clash_sub(username: str, proxies: dict):
     conf = ClashConfiguration()
     for host in XRAY_HOSTS:
         for proxy_type, settings in proxies.items():
-            conf.add(host['remark'], host['hostname'], proxy_type, settings.dict(no_obj=True))
+            conf.add(host['remark'],
+                     host['address'],
+                     proxy_type,
+                     settings.dict(no_obj=True),
+                     custom_sni=host['sni'],
+                     custom_host=host['host'])
     return conf
 
 


### PR DESCRIPTION
With this PR, we can set a custom `sni` or `host` for each host in `XRAY_HOSTS`. I have tested it and works fine both in dev and in production.

Two syntaxes are supported for `XRAY_HOSTS` lines:

1. The simple `remark@address` syntax.

2. JSON syntax:
   ```
   {"remark": "myremark", "address": "10.20.30.40", "sni": "mysni.example.com", "host": "myhost.example.com"}
   ```


Example `.env`:


```
XRAY_HOSTS = '
Server@127.0.0.1
Bridge@192.168.1.10

# Empty lines and comments are supported
John\'s Domain@john.example.com

# You can set custom sni and host using JSON format:
{"remark": "CDN2", "address": "10.20.30.40", "sni": "my.example2.com", "host": "my.example2.com"}
'
```