### PR TITLE
 Add *-custom.json to the git ignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,6 @@ cython_debug/
 v2ray-core
 xray-core
 xray-dev.json
+
+# don't track custom.json configs, such as xray-custom.json
+*-custom.json


### PR DESCRIPTION
there is no need to track all the json configs, so you can create and experiment with different configs on the server
and not mess with git and create any number of config files that end with `-custom.json`.

for example: `xray-custom.json` or `xray-test-custom.json`.
