### PR TITLE
Allow sudo users to get all users

### DIFF
--- a/app/views/system.py
+++ b/app/views/system.py
@@ -17,8 +17,8 @@ def get_system_stats(db: Session = Depends(get_db), admin: Admin = Depends(Admin
     system = crud.get_system_usage(db)
     dbadmin: Union[Admin, None] = crud.get_admin(db, admin.username)
 
-    total_user = crud.get_users_count(db, admin=dbadmin)
-    users_active = crud.get_users_count(db, status=UserStatus.active, admin=dbadmin)
+    total_user = crud.get_users_count(db, admin=dbadmin if not admin.is_sudo else None)
+    users_active = crud.get_users_count(db, status=UserStatus.active, admin=dbadmin if not admin.is_sudo else None)
 
     return SystemStats(
         mem_total=mem.total,

--- a/app/views/user.py
+++ b/app/views/user.py
@@ -197,7 +197,7 @@ def get_users(offset: int = None,
                                   username=username,
                                   status=status,
                                   sort=sort,
-                                  admin=dbadmin,
+                                  admin=dbadmin if not admin.is_sudo else None,
                                   return_with_count=True)
 
     return {"users": users, "total": count}


### PR DESCRIPTION
I noticed that db sudo users could not get all of the users. As sudo users are meant to have access to almost everything, they should have access to all users. It was fine for env sudo users because they had no `dbadmin`, but for those stored in database, the get_users() would return only their own user.