### PR TITLE
Models: Change `gt=-1` in Fields to `ge=0`

### DIFF
--- a/app/models/user.py
+++ b/app/models/user.py
@@ -38,7 +38,7 @@ class UserDataLimitResetStrategy(str, Enum):
 class User(BaseModel):
     proxies: Dict[ProxyTypes, ProxySettings] = {}
     expire: int = None
-    data_limit: Union[None, int] = Field(gt=-1, default=None, description="data_limit can be 0 or greater")
+    data_limit: Union[None, int] = Field(ge=0, default=None, description="data_limit can be 0 or greater")
     data_limit_reset_strategy: UserDataLimitResetStrategy = UserDataLimitResetStrategy.no_reset
     inbounds: Dict[ProxyTypes, List[str]] = {}
 

--- a/app/models/user_template.py
+++ b/app/models/user_template.py
@@ -7,9 +7,9 @@ from app import xray
 
 class UserTemplate(BaseModel):
     name: str | None = None
-    data_limit: int | None = Field(gt=-1, default=None, description="data_limit can be 0 or greater")
+    data_limit: int | None = Field(ge=0, default=None, description="data_limit can be 0 or greater")
     expire_duration: int | None = Field(
-        gt=-1, default=None, description="expire_duration can be 0 or greater in seconds")
+        ge=0, default=None, description="expire_duration can be 0 or greater in seconds")
     username_prefix: str | None = Field(max_length=20, min_length=1, default=None)
     username_suffix: str | None = Field(max_length=20, min_length=1, default=None)
 


### PR DESCRIPTION
some openapi auto code generators seem to have a problem with `gt=-1`, so changed that