### PR TITLE
Telegram: bugfix - remeove user from xray and re-add it if the status was active

### DIFF
--- a/app/telegram/handlers/admin.py
+++ b/app/telegram/handlers/admin.py
@@ -918,6 +918,10 @@ def confirm_user_command(call: types.CallbackQuery):
 
             user = UserResponse.from_orm(db_user)
 
+        xray_remove_user(db_user)
+        if user.status == UserStatus.active:
+            xray_add_user(db_user)
+
         bot.answer_callback_query(call.id, "✅ User updated successfully.")
         text = get_user_info_text(username=user.username,
                                   sub_url=user.subscription_url,


### PR DESCRIPTION
the user wouldn't be added to xray again if it was removed due to expiration or data limitation.