### PR TITLE
Backend: Improve server statistics

### DIFF
--- a/app/models/system.py
+++ b/app/models/system.py
@@ -4,7 +4,11 @@ from pydantic import BaseModel
 class SystemStats(BaseModel):
     mem_total: int
     mem_used: int
+    cpu_cores: int
+    cpu_usage: float
     total_user: int
     users_active: int
     incoming_bandwidth: int
     outgoing_bandwidth: int
+    incoming_bandwidth_speed: int
+    outgoing_bandwidth_speed: int

--- a/app/utils/system.py
+++ b/app/utils/system.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass
 
 import psutil
 
+from app import scheduler
+
 
 @dataclass
 class MemoryStat():
@@ -16,7 +18,7 @@ class MemoryStat():
 @dataclass
 class CPUStat():
     cores: int
-    percent: int
+    percent: float
 
 
 def cpu_usage() -> CPUStat:
@@ -26,6 +28,53 @@ def cpu_usage() -> CPUStat:
 def memory_usage() -> MemoryStat:
     mem = psutil.virtual_memory()
     return MemoryStat(total=mem.total, used=mem.used, free=mem.available)
+
+
+@dataclass
+class RealtimeBandwidth:
+    def __post_init__(self):
+        io = psutil.net_io_counters()
+        self.bytes_recv = io.bytes_recv
+        self.bytes_sent = io.bytes_sent
+        self.packets_recv = io.packets_recv
+        self.packet_sent = io.packets_sent
+
+    incoming_bytes: int
+    outgoing_bytes: int
+    incoming_packets: int
+    outgoing_packets: int
+
+    bytes_recv: int = None
+    bytes_sent: int = None
+    packets_recv: int = None
+    packet_sent: int = None
+
+
+@dataclass
+class RealtimeBandwidthStat:
+    incoming_bytes: int
+    outgoing_bytes: int
+    incoming_packets: int
+    outgoing_packets: int
+
+
+rt_bw = RealtimeBandwidth(
+    incoming_bytes=0, outgoing_bytes=0, incoming_packets=0, outgoing_packets=0)
+
+
+@scheduler.scheduled_job('interval', seconds=1)
+def record_realtime_bandwidth() -> None:
+    io = psutil.net_io_counters()
+    rt_bw.incoming_bytes, rt_bw.bytes_recv = io.bytes_recv - rt_bw.bytes_recv, io.bytes_recv
+    rt_bw.outgoing_bytes, rt_bw.bytes_sent = io.bytes_sent - rt_bw.bytes_sent, io.bytes_sent
+    rt_bw.incoming_packets, rt_bw.packets_recv = io.packets_recv - rt_bw.packets_recv, io.packets_recv
+    rt_bw.outgoing_packets, rt_bw.packet_sent = io.packets_sent - rt_bw.packet_sent, io.packets_sent
+
+
+def realtime_bandwith() -> RealtimeBandwidthStat:
+    return RealtimeBandwidthStat(
+        incoming_bytes=rt_bw.incoming_bytes, outgoing_bytes=rt_bw.outgoing_bytes,
+        incoming_packets=rt_bw.incoming_packets, outgoing_packets=rt_bw.outgoing_packets)
 
 
 def random_password() -> str:

--- a/app/views/system.py
+++ b/app/views/system.py
@@ -9,25 +9,31 @@ from app.models.proxy import ProxyHost, ProxyInbound, ProxyTypes
 from app.models.system import SystemStats
 from app.models.user import UserStatus
 from app.utils.store import XrayStore
-from app.utils.system import memory_usage
+from app.utils.system import memory_usage, cpu_usage, realtime_bandwith
 
 
 @app.get("/api/system", tags=["System"], response_model=SystemStats)
 def get_system_stats(db: Session = Depends(get_db), admin: Admin = Depends(Admin.get_current)):
     mem = memory_usage()
+    cpu = cpu_usage()
     system = crud.get_system_usage(db)
     dbadmin: Union[Admin, None] = crud.get_admin(db, admin.username)
 
     total_user = crud.get_users_count(db, admin=dbadmin if not admin.is_sudo else None)
     users_active = crud.get_users_count(db, status=UserStatus.active, admin=dbadmin if not admin.is_sudo else None)
+    realtime_bandwidth_stats = realtime_bandwith()
 
     return SystemStats(
         mem_total=mem.total,
         mem_used=mem.used,
+        cpu_cores=cpu.cores,
+        cpu_usage=cpu.percent,
         total_user=total_user,
         users_active=users_active,
         incoming_bandwidth=system.uplink,
         outgoing_bandwidth=system.downlink,
+        incoming_bandwidth_speed=realtime_bandwidth_stats.incoming_bytes,
+        outgoing_bandwidth_speed=realtime_bandwidth_stats.outgoing_bytes,
     )
 
 


### PR DESCRIPTION
fixes #134 

add `cpu_cores` and `cpu_usage` to get number of cpu cores and percentage of cpu usage.

add `incoming_bandwidth_speed` and `outgoing_bandwidth_speed` to show real time data about system's bandwidth
	add utility functions to monitor outgoing and incoming bytes/packets
	realtime data is available in `rt_bw` inside the `utils/system.py`,  and it will be updated every second