### PR TITLE
fix:  use empty string("") instead of "none" for vless flow

### DIFF
--- a/app/dashboard/src/components/RadioGroup.tsx
+++ b/app/dashboard/src/components/RadioGroup.tsx
@@ -387,12 +387,11 @@ const RadioCard: FC<
                   fontSize="xs"
                   size="sm"
                   borderRadius="6px"
-                  placeholder={t("default") + ": none"}
                   {...form.register("proxies.vless.flow")}
                 >
-                  {vlessFlows.map((flow) => (
-                    <option key={flow} value={flow}>
-                      {flow}
+                  {vlessFlows.map((entry) => (
+                    <option key={entry.title} value={entry.value}>
+                      {entry.title}
                     </option>
                   ))}
                 </Select>
@@ -441,7 +440,6 @@ const RadioCard: FC<
                   fontSize="xs"
                   size="sm"
                   borderRadius="6px"
-                  placeholder={t("default") + ": chacha20-poly1305"}
                   {...form.register("proxies.shadowsocks.method")}
                 >
                   {shadowsocksMethods.map((method) => (

--- a/app/dashboard/src/components/UserDialog.tsx
+++ b/app/dashboard/src/components/UserDialog.tsx
@@ -134,7 +134,7 @@ const getDefaultValues = (): FormType => {
       vless: { id: "", flow: "" },
       vmess: { id: ""},
       trojan: { password: "" },
-      shadowsocks: { password: "", method: "" }
+      shadowsocks: { password: "", method: "chacha20-poly1305" }
     }
   };
 };

--- a/app/dashboard/src/constants/Proxies.tsx
+++ b/app/dashboard/src/constants/Proxies.tsx
@@ -17,8 +17,8 @@ export const proxyHostSecurity: { title: string; value: ProxyHostSecurity }[] =
   ];
 
 export const vlessFlows = [
-  "none",
-  "xtls-rprx-vision",
+  { title: "none", value: "" },
+  { title: "xtls-rprx-vision", value: "xtls-rprx-vision"},
 ];  
 
 export const shadowsocksMethods = [

--- a/app/dashboard/src/locales/i18n.js
+++ b/app/dashboard/src/locales/i18n.js
@@ -34,11 +34,11 @@ i18n
           expired: "Expired {{time}}",
           dateFormat: "MMMM d, yyy",
           inbound: "Inbound",
-          default: "Default",
 
           // Login
           "login.loginYourAccount": "Login to your account",
           "login.welcomeBack": "Welcome back, please enter your details",
+          "login.fieldRequired": "This field is required",
 
           // Header
           "header.hostsSetting": "Hosts Settings",
@@ -152,11 +152,11 @@ i18n
           expired: "{{time}}失效",
           dateFormat: "MM/dd/yyyy",
           inbound: "入站",
-          default: "默认",
 
           // page login
           "login.loginYourAccount": "登录您的帐号",
           "login.welcomeBack": "欢迎回来，请输入您的详细信息",
+          "login.fieldRequired": "此项必填",
 
           // Header
           "header.hostsSetting": "设置",

--- a/app/dashboard/src/pages/Login.tsx
+++ b/app/dashboard/src/pages/Login.tsx
@@ -26,8 +26,8 @@ import { useTranslation } from "react-i18next";
 import { Language } from "components/Language";
 
 const schema = z.object({
-  username: z.string().min(1, "This field is required"),
-  password: z.string().min(1, "This field is required"),
+  username: z.string().min(1, "login.fieldRequired"),
+  password: z.string().min(1, "login.fieldRequired"),
 });
 
 export const LogoIcon = chakra(Logo, {
@@ -103,22 +103,20 @@ export const Login: FC = () => {
               <form onSubmit={handleSubmit(login)}>
                 <VStack mt={4} rowGap={2}>
                   <FormControl>
-                    {/* <FormLabel>{t("username")}</FormLabel> */}
                     <Input
                       w="full"
                       placeholder={t("username") || "Username"}
                       {...register("username")}
-                      error={errors?.username?.message as string}
+                      error={t(errors?.username?.message as string) || ""}
                     />
                   </FormControl>
                   <FormControl>
-                    {/* <FormLabel>{t("password")}</FormLabel> */}
                     <Input
                       w="full"
                       type="password"
                       placeholder={t("password") || "Password"}
                       {...register("password")}
-                      error={errors?.password?.message as string}
+                      error={t(errors?.password?.message as string) || ""}
                     />
                   </FormControl>
                   {error && (


### PR DESCRIPTION
error message from restart: VLESS clients: "flow" doesn\'t support "none" in this version'