### PR TITLE
add slave node service and stat proxy service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,10 @@ XRAY_JSON = "xray.json"
 XRAY_EXECUTABLE_PATH = "/usr/local/bin/xray"
 XRAY_ASSETS_PATH = "/usr/local/share/xray"
 
+# SLAVE_SSL_CERTFILE = "/var/lib/marzban/server-custom.crt"
+# SLAVE_SSL_KEYFILE = "/var/lib/marzban/server-custom.key"
+# SLAVE_PORT = 8100
+# SLAVE_API_PORT = 8101
 
 # XRAY_SUBSCRIPTION_URL_PREFIX = "http://example.com"
 

--- a/.gitignore
+++ b/.gitignore
@@ -154,6 +154,8 @@ xray-dev.json
 
 # don't track custom/dev.json/yaml/yml configs, such as xray-custom.json or clash-dev.yaml
 *-custom.json
+*-custom.key
+*-custom.crt
 *-custom.yaml
 *-custom.yml
 *-dev.json

--- a/app/dashboard/build.sh
+++ b/app/dashboard/build.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+cd `dirname $0`
+
+VITE_BASE_API=/api/ npm run build --if-present -- --outDir build --base '/dashboard/'
+cp ./build/index.html ./build/404.html

--- a/app/jobs/2_review_nodes.py
+++ b/app/jobs/2_review_nodes.py
@@ -1,0 +1,14 @@
+from threading import Thread
+from app import logger, scheduler, xray
+
+def review():
+    config = xray.config.include_db_users()
+    for nodeid, node in xray.nodes.items():
+        try:
+            if not node.connected:
+                logger.info(f"\"{node.name}\" node is disconnected.")
+                Thread(target=xray.operations.connect_node, args=(nodeid, config)).start()
+        except Exception:
+            pass
+
+scheduler.add_job(review, 'interval', seconds=15)

--- a/app/jobs/3_record_nodes_usages.py
+++ b/app/jobs/3_record_nodes_usages.py
@@ -1,0 +1,59 @@
+from operator import attrgetter
+
+from app import scheduler, xray
+from app.db import engine
+from app.db.models import Node, User
+from sqlalchemy import bindparam, update
+
+
+def record_users_usage():
+    for node in xray.nodes.values():
+        if node.connected:
+            with engine.connect() as conn:
+                try:
+                    params = [
+                        {"name": stat.name, "value": stat.value}
+                        for stat in filter(attrgetter('value'), node.api.get_users_stats(reset=True))
+                    ]
+                except xray.exceptions.ConnectionError:
+                    pass
+
+                if not params:
+                    continue
+
+                stmt = update(User). \
+                    where(User.username == bindparam('name')). \
+                    values(used_traffic=User.used_traffic + bindparam('value'))
+
+                conn.execute(stmt, params)
+
+scheduler.add_job(record_users_usage, 'interval', seconds=20)
+
+
+def record_outbounds_usage():
+   for node in xray.nodes.values():
+        if node.connected:
+            with engine.connect() as conn:
+                try:
+                    params = [
+                        {"node_name": node.name, "up": stat.value, "down": 0} if stat.link == "uplink" else 
+                        {"node_name": node.name, "up": 0, "down": stat.value}
+                        for stat in filter(attrgetter('value'), node.api.get_outbounds_stats(reset=True))
+                    ]
+                except xray.exceptions.ConnectionError:
+                    pass
+
+                if not params:
+                    continue
+
+                stmt = update(Node). \
+                    where(Node.name == bindparam('node_name')). \
+                    values(
+                        uplink=Node.uplink + bindparam('up'),
+                        downlink=Node.downlink + bindparam('down')
+                    )
+
+                conn.execute(stmt, params)
+
+
+scheduler.add_job(record_outbounds_usage, 'interval', seconds=15)

--- a/app/xray/__init__.py
+++ b/app/xray/__init__.py
@@ -2,7 +2,7 @@ from random import randint
 from typing import Dict
 
 from app.utils.system import check_port
-from app.xray import operations
+from app.xray import operations, slave
 from app.xray.config import XRayConfig
 from app.xray.core import XRayCore
 from app.xray.node import XRayNode
@@ -35,6 +35,7 @@ __all__ = [
     "operations",
     "exceptions",
     "exc",
+    "slave",
     "types",
     "XRayConfig",
     "XRayCore",

--- a/app/xray/config.py
+++ b/app/xray/config.py
@@ -9,7 +9,11 @@ from typing import Union
 from app.db import GetDB, get_users
 from app.models.proxy import ProxySettings
 from app.models.user import UserStatus
-from config import XRAY_EXCLUDE_INBOUND_TAGS, XRAY_FALLBACKS_INBOUND_TAG
+from config import (
+    XRAY_EXCLUDE_INBOUND_TAGS,
+    XRAY_FALLBACKS_INBOUND_TAG,
+    SLAVE_SSL_CERTFILE,
+    SLAVE_SSL_KEYFILE)
 
 
 class XRayConfig(dict):
@@ -228,6 +232,10 @@ class XRayConfig(dict):
                 self.inbounds_by_protocol[inbound['protocol']].append(settings)
             except KeyError:
                 self.inbounds_by_protocol[inbound['protocol']] = [settings]
+
+    def update_api_port(self, api_port: int):
+        inbound = self.get_inbound("API_INBOUND")
+        inbound["port"] = api_port
 
     def add_inbound_client(self, inbound_tag: str, email: str, settings: dict):
         client = {"email": email, **settings}

--- a/app/xray/node.py
+++ b/app/xray/node.py
@@ -1,9 +1,11 @@
 import tempfile
 import threading
+import ssl
 from typing import List
 
 import rpyc
 
+from app import logger
 from app.xray.config import XRayConfig
 from xray_api import XRay as XRayAPI
 
@@ -14,7 +16,8 @@ class XRayNode:
                  address: str,
                  port: int,
                  api_port: int,
-                 ssl_cert: str):
+                 ssl_cert: str,
+                 name: str = "Master"):
 
         class Service(rpyc.Service):
             def __init__(self,
@@ -47,6 +50,7 @@ class XRayNode:
         self.port = port
         self.api_port = api_port
         self.ssl_cert = ssl_cert
+        self.name = name
 
         self.started = False
 
@@ -73,6 +77,7 @@ class XRayNode:
                                     self.port,
                                     service=self._service,
                                     ca_certs=self._certfile.name,
+                                    cert_reqs=ssl.CERT_REQUIRED,
                                     keepalive=True)
             try:
                 conn.ping()
@@ -112,23 +117,30 @@ class XRayNode:
             self._api = XRayAPI(
                 address=self.address,
                 port=self.api_port,
-                ssl_cert=self.ssl_cert.encode(),
-                ssl_target_name="Gozargah"
+                ssl_cert=self.ssl_cert.encode()
             )
             return self._api
 
     def start(self, config: XRayConfig):
         json_config = config.to_json()
-        self.remote.start(json_config)
-        self.started = True
+        status, err = self.remote.start(json_config)
+        if status is True:
+            self.started = True
+        else:
+            logger.error(f"Got error from \"{self.name}\" node:\n{err}")
 
     def stop(self):
-        self.remote.stop()
-        self.started = False
+        if self.started:
+            self.remote.stop()
+            self.started = False
 
     def restart(self, config: XRayConfig):
         json_config = config.to_json()
-        self.remote.restart(json_config)
+        status, err = self.remote.restart(json_config)
+        if status is False:
+            self.started = False
+            logger.error(f"Got error from slave \"{self.name}\" node:\n{err}")
+
 
     def on_start(self, func: callable):
         self._service.add_startup_func(func)

--- a/app/xray/operations.py
+++ b/app/xray/operations.py
@@ -19,6 +19,10 @@ def add_user(user: User):
             except xray.exc.EmailExistsError:
                 pass
 
+    config = xray.config.include_db_users()
+    for node in xray.nodes.values():
+        node.restart(config)
+
 
 def remove_user(user: User):
     for inbound_tag in xray.config.inbounds_by_tag:
@@ -26,6 +30,10 @@ def remove_user(user: User):
             xray.api.remove_inbound_user(tag=inbound_tag, email=user.username)
         except xray.exc.EmailNotFoundError:
             pass
+
+    config = xray.config.include_db_users()
+    for node in xray.nodes.values():
+        node.restart(config)
 
 
 def remove_node(node_id: int):
@@ -44,7 +52,8 @@ def add_node(dbnode: DBNode):
     xray.nodes[dbnode.id] = XRayNode(address=dbnode.address,
                                      port=dbnode.port,
                                      api_port=dbnode.api_port,
-                                     ssl_cert=dbnode.certificate)
+                                     ssl_cert=dbnode.certificate,
+                                     name = dbnode.name)
 
     return xray.nodes[dbnode.id]
 

--- a/app/xray/slave.py
+++ b/app/xray/slave.py
@@ -1,0 +1,134 @@
+import rpyc
+import logging
+import grpc
+from concurrent import futures
+from threading import Thread
+from rpyc.utils.authenticators import SSLAuthenticator
+from rpyc.utils.server import ThreadedServer
+from app import xray
+from app.xray.core import XRayCore
+from app.xray.config import XRayConfig
+from xray_api import XRay
+from xray_api.proto.app.stats.command import command_pb2_grpc
+
+from config import (
+    XRAY_EXECUTABLE_PATH,
+    XRAY_ASSETS_PATH,
+    SLAVE_SSL_CERTFILE,
+    SLAVE_SSL_KEYFILE,
+    SLAVE_PORT,
+    SLAVE_API_PORT
+)
+
+class XRayAPI(XRay):
+    def GetStats(self, request, context):
+        stub = command_pb2_grpc.StatsServiceStub(self._channel)
+        return stub.GetStats(request)
+
+    def QueryStats(self, request, context):
+        stub = command_pb2_grpc.StatsServiceStub(self._channel)
+        return stub.QueryStats(request)
+
+    def GetSysStats(self, request, context):
+        stub = command_pb2_grpc.StatsServiceStub(self._channel)
+        return stub.GetSysStats(request)
+
+logger = logging.getLogger("slave")
+logger.setLevel(logging.DEBUG)
+ch = logging.StreamHandler()
+ch.setFormatter(logging.Formatter("%(levelname)s: %(message)s"))
+logger.addHandler(ch)
+
+api_port = None
+api = None
+
+core = XRayCore(XRAY_EXECUTABLE_PATH, XRAY_ASSETS_PATH)
+
+def start_stat():
+    class RequestRpc(command_pb2_grpc.StatsServiceServicer):
+        def GetStats(self, request, context):
+            return api.GetStats(request, context)
+
+        def QueryStats(self, request, context):
+            return api.QueryStats(request, context)
+
+        def GetSysStats(self, request, context):
+            return api.GetSysStats(request, context)
+        
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=5))
+    command_pb2_grpc.add_StatsServiceServicer_to_server(RequestRpc(), server)
+    with open(SLAVE_SSL_KEYFILE, 'rb') as f:
+        key = f.read()
+    with open(SLAVE_SSL_CERTFILE, 'rb') as f:
+        cert = f.read()
+    server_credentials = grpc.ssl_server_credentials(((key, cert,),))
+    server.add_secure_port(f'[::]:{SLAVE_API_PORT}', server_credentials)
+    server.start()
+    logger.info(f"stat started, listen on {SLAVE_API_PORT}")
+    server.wait_for_termination()
+
+def start_slave():
+    @rpyc.service
+    class SlaveService(rpyc.Service):
+        @rpyc.exposed
+        def start(self, config):
+            if core.started:
+                core.stop()
+
+            config = XRayConfig(config)
+            config.update_api_port(api_port)
+            self.ouput_running_config(config)
+
+            try:
+                core.start(config)
+                logger.info("start xray")
+                return True, "xray started"
+            except RuntimeError as err:
+                logger.error(err)
+                return False, err
+
+        @rpyc.exposed
+        def stop(self):
+            core.stop()
+            logger.info("stop xray")
+
+        @rpyc.exposed
+        def restart(self, config):
+            config = XRayConfig(config)
+            config.update_api_port(api_port)
+            self.ouput_running_config(config)
+            try:
+                core.restart(config)
+                logger.info("restart xray")
+                return True, "xray restarted"
+            except RuntimeError as err:
+                logger.error(err)
+                return False, err
+
+        @rpyc.exposed
+        def ouput_running_config(self, config: XRayConfig):
+            with open("xray-running-custom.json", "w") as file:
+                file.write(config.to_json())
+                file.flush()
+                file.close()
+
+    logger.info(f"ssl keyfile: {SLAVE_SSL_KEYFILE}")
+    logger.info(f"ssl certfile: {SLAVE_SSL_CERTFILE}")
+    logger.info(f"slave started, listen on {SLAVE_PORT}")
+    authenticator = SSLAuthenticator(SLAVE_SSL_KEYFILE, SLAVE_SSL_CERTFILE)
+    slave = ThreadedServer(SlaveService, port = SLAVE_PORT, reuse_addr = True, authenticator = authenticator)
+    slave.start()
+
+def start():
+    global api_port
+    global api
+
+    api_port = xray.config.api_port
+    api = XRayAPI(xray.config.api_host, api_port)
+
+    Thread(target=start_stat).start()
+    start_slave()
+
+__all__ = [
+    "start"
+]

--- a/config.py
+++ b/config.py
@@ -13,6 +13,10 @@ UVICORN_UDS = config("UVICORN_UDS", default=None)
 UVICORN_SSL_CERTFILE = config("UVICORN_SSL_CERTFILE", default=None)
 UVICORN_SSL_KEYFILE = config("UVICORN_SSL_KEYFILE", default=None)
 
+SLAVE_SSL_CERTFILE = config("SLAVE_SSL_CERTFILE", default=None)
+SLAVE_SSL_KEYFILE = config("SLAVE_SSL_KEYFILE", default=None)
+SLAVE_PORT = config("SLAVE_PORT", cast=int, default=8100)
+SLAVE_API_PORT = config("SLAVE_API_PORT", cast=int, default=8101)
 
 DEBUG = config("DEBUG", default=False, cast=bool)
 DOCS = config("DOCS", default=False, cast=bool)

--- a/marzban-slave.service
+++ b/marzban-slave.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Marzban Slave Service
+Documentation=https://github.com/gozargah/marzban
+After=network.target nss-lookup.target
+
+[Service]
+ExecStart=/usr/bin/env python3 /var/lib/marzban/slave.py
+Restart=on-failure
+WorkingDirectory=/var/lib/marzban
+
+[Install]
+WantedBy=multi-user.target

--- a/slave.py
+++ b/slave.py
@@ -1,0 +1,3 @@
+from app import xray
+
+xray.slave.start()

--- a/xray_api/base.py
+++ b/xray_api/base.py
@@ -12,6 +12,7 @@ class XRayBase(object):
             self.address = address
             self.port = port
             creds = grpc.ssl_channel_credentials(root_certificates=ssl_cert)
+            opts = None
             if ssl_target_name is not None:
                 opts = (('grpc.ssl_target_name_override', ssl_target_name,),)
             self._channel = grpc.secure_channel(f"{address}:{port}",


### PR DESCRIPTION
Thanks for the marzban-node, it is great for manage multiple nodes. I had use it in my vps.
![IMG_AC8C3DB4D4BE-1](https://user-images.githubusercontent.com/2108342/235185371-db2f87a8-6e39-4326-a1e8-e6010022fbe4.jpeg)

This patch add slave service and stat proxy service:
1. slave service: it used to receive RPC of master.
2. stat proxy service: it receive gRPC of api, and forward local api port. 