### PR TITLE
fixed an issue that caused crash when a port range or multiple comma separated ports are used in xray_config.json

### DIFF
--- a/app/models/proxy.py
+++ b/app/models/proxy.py
@@ -143,4 +143,4 @@ class ProxyInbound(BaseModel):
     protocol: ProxyTypes
     network: str
     tls: str
-    port: int
+    port: Union[int, str]


### PR DESCRIPTION
https://xtls.github.io/config/inbound.html#inboundobject 
as it's written here, we can use 
```
Port. The accepted formats are as follows:

Integer number: The actual port number.
Environment variables: Start with , followed by the name of an environment variable, such as . Xray parses this environment variable as a string."env:""env:PORT"
String: Can be a string of numeric type, such as ; Or a numeric range, such as port 5 to port 10, which represents the 6 ports. You can use commas for 11 ports, such as port 13, port 15, port 17 through port 5."1234""5-10"11,13,15-17
```
either an Integer or String value as PORT, but in marzban only integer was accepted that was causing crashes :

```
6efbcacdca07_marz-marzban-1  |     raise ValidationError(errors, field.type_)
6efbcacdca07_marz-marzban-1  | pydantic.error_wrappers.ValidationError: 4 validation errors for ProxyInbound
```

