### PR TITLE
Marzban CLI: User's list and set-owner implemented

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -16,6 +16,7 @@ $ marzban-cli [OPTIONS] COMMAND [ARGS]...
 
 * `admin`
 * `subscription`
+* `user`
 
 ## `marzban-cli admin`
 
@@ -184,4 +185,61 @@ $ marzban-cli subscription get-link [OPTIONS]
 **Options**:
 
 * `-u, --username TEXT`: [required]
+* `--help`: Show this message and exit.
+
+## `marzban-cli user`
+
+**Usage**:
+
+```console
+$ marzban-cli user [OPTIONS] COMMAND [ARGS]...
+```
+
+**Options**:
+
+* `--help`: Show this message and exit.
+
+**Commands**:
+
+* `list`: Displays a table of users
+* `set-owner`: Transfers user's ownership
+
+### `marzban-cli user list`
+
+Displays a table of users
+
+NOTE: Sorting is not currently available.
+
+**Usage**:
+
+```console
+$ marzban-cli user list [OPTIONS]
+```
+
+**Options**:
+
+* `-o, --offset INTEGER`
+* `-l, --limit INTEGER`
+* `-u, --username TEXT`: Search by username
+* `--status [active|disabled|limited|expired]`
+* `--admin, --owner TEXT`: Search by owner admin's username
+* `--help`: Show this message and exit.
+
+### `marzban-cli user set-owner`
+
+Transfers user's ownership
+
+NOTE: This command needs additional confirmation for users who already have an owner.
+
+**Usage**:
+
+```console
+$ marzban-cli user set-owner [OPTIONS]
+```
+
+**Options**:
+
+* `-u, --username TEXT`
+* `--admin, --owner TEXT`: Admin's username
+* `-y, --yes`: Skips confirmation.
 * `--help`: Show this message and exit.

--- a/cli/admin.py
+++ b/cli/admin.py
@@ -14,7 +14,6 @@ from app.models.admin import AdminCreate, AdminPartialModify
 from . import utils
 
 app = typer.Typer(no_args_is_help=True)
-console = Console()
 
 
 @app.command(name="list")
@@ -25,17 +24,16 @@ def list_admins(
 ):
     """Displays a table of admins"""
     with GetDB() as db:
-        table = Table("Username", "Is sudo", "Created at")
         admins: list[Admin] = crud.get_admins(db, offset=offset, limit=limit, username=username)
-
-        for admin in admins:
-            table.add_row(
-                str(admin.username),
-                "✔️" if admin.is_sudo else "✖️",
-                admin.created_at.strftime("%d %B %Y, %H:%M:%S")
-            )
-
-        console.print(table)
+        utils.print_table(
+            table=Table("Username", "Is sudo", "Created at"),
+            rows=[
+                (str(admin.username),
+                 "✔️" if admin.is_sudo else "✖️",
+                 utils.readable_datetime(admin.created_at))
+                for admin in admins
+            ]
+        )
 
 
 @app.command(name="delete")
@@ -89,7 +87,7 @@ def update_admin(username: str = typer.Option(..., *utils.FLAGS["username"], pro
     """
 
     def _get_modify_model(admin: Admin):
-        console.print(
+        Console().print(
             Panel(f'Editing "{username}". Just press "Enter" to leave each field unchanged.')
         )
 

--- a/cli/user.py
+++ b/cli/user.py
@@ -1,0 +1,84 @@
+from typing import Optional
+from rich.table import Table
+
+import typer
+
+from app.db import GetDB
+from app.db import crud
+from app.db.models import User
+from app.utils.system import readable_size
+from . import utils
+
+app = typer.Typer(no_args_is_help=True)
+
+
+@app.command(name="list")
+def list_users(
+    offset: Optional[int] = typer.Option(None, *utils.FLAGS["offset"]),
+    limit: Optional[int] = typer.Option(None, *utils.FLAGS["limit"]),
+    username: Optional[str] = typer.Option(None, *utils.FLAGS["username"], help="Search by username"),
+    status: Optional[crud.UserStatus] = typer.Option(None, *utils.FLAGS["status"]),
+    admin: Optional[str] = typer.Option(None, "--admin", "--owner", help="Search by owner admin's username")
+):
+    """
+    Displays a table of users
+
+    NOTE: Sorting is not currently available.
+    """
+    with GetDB() as db:
+        users: list[User] = crud.get_users(
+            db=db, offset=offset, limit=limit,
+            username=username, status=status,
+            admin=crud.get_admin(db, admin) if admin else None
+        )
+
+        utils.print_table(
+            table=Table(
+                "ID", "Username", "Status", "Used traffic",
+                "Data limit", "Reset strategy", "Expires at", "Owner",
+            ),
+            rows=[
+                (
+                    str(user.id),
+                    user.username,
+                    user.status.value,
+                    readable_size(user.used_traffic),
+                    readable_size(user.data_limit) if user.data_limit else "Unlimited",
+                    user.data_limit_reset_strategy.value,
+                    utils.readable_datetime(user.expire),
+                    user.admin.username
+                )
+                for user in users
+            ]
+        )
+
+
+@app.command(name="set-owner")
+def set_owner(
+    username: str = typer.Option(None, *utils.FLAGS["username"], prompt=True),
+    admin: str = typer.Option(None, "--admin", "--owner", prompt=True, help="Admin's username"),
+    yes_to_all: bool = typer.Option(False, *utils.FLAGS["yes_to_all"], help="Skips confirmations")
+):
+    """
+    Transfers user's ownership
+
+    NOTE: This command needs additional confirmation for users who already have an owner.
+    """
+    with GetDB() as db:
+        user: User = utils.raise_if_falsy(
+            crud.get_user(db, username=username), f'User "{username}" not found.')
+
+        dbadmin: Admin = utils.raise_if_falsy(
+            crud.get_admin(db, username=admin), f'Admin "{admin}" not found.')
+
+        # Ask for confirmation if user already has an owner
+        if user.admin and not yes_to_all and not typer.confirm(
+            f'{username}\'s current owner is "{user.admin.username}".'
+            f' Are you sure about transferring its ownership to "{admin}"?'
+        ):
+            utils.error("Aborted.")
+
+        user.admin = dbadmin
+        db.commit()
+
+        utils.success(f'{username}\'s owner successfully set to "{admin}".')

--- a/cli/user.py
+++ b/cli/user.py
@@ -45,7 +45,7 @@ def list_users(
                     readable_size(user.used_traffic),
                     readable_size(user.data_limit) if user.data_limit else "Unlimited",
                     user.data_limit_reset_strategy.value,
-                    utils.readable_datetime(user.expire),
+                    utils.readable_datetime(user.expire, include_time=False),
                     user.admin.username
                 )
                 for user in users

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -61,8 +61,26 @@ def print_table(
     (console or rich_console).print(table)
 
 
-def readable_datetime(date_time: Optional[datetime]):
-    return date_time.strftime("%d %B %Y, %H:%M:%S") if date_time else "-"
+def readable_datetime(
+    date_time: Union[datetime, int, None],
+    include_date: bool = True,
+    include_time: bool = True
+):
+    def get_datetime_format():
+        dt_format = ""
+        if include_date:
+            dt_format += "%d %B %Y"
+        if include_time:
+            if dt_format:
+                dt_format += ", "
+            dt_format += "%H:%M:%S"
+
+        return dt_format
+
+    if isinstance(date_time, int):
+        date_time = datetime.fromtimestamp(date_time)
+
+    return date_time.strftime(get_datetime_format()) if date_time else "-"
 
 
 def raise_if_falsy(obj: T, message: str) -> T:

--- a/cli/utils.py
+++ b/cli/utils.py
@@ -1,10 +1,17 @@
 import pydoc
-from typing import Union
 import typer
+from datetime import datetime
+from typing import Any, Iterable, Optional, TypeVar, Union
+
+from rich.table import Table
+from rich.console import Console
 
 from app.db import crud
 from app.db.models import User
 
+T = TypeVar("T")
+
+rich_console = Console()
 PASSWORD_ENVIRON_NAME = "MARZBAN_ADMIN_PASSWORD"
 
 FLAGS: dict[str, tuple] = {
@@ -14,7 +21,8 @@ FLAGS: dict[str, tuple] = {
     "yes_to_all": ("--yes", "-y"),
     "is_sudo": ("--sudo/--no-sudo",),
     "format": ("--format", "-f"),
-    "output_file": ("--output", "-o")
+    "output_file": ("--output", "-o"),
+    "status": ("--status",),
 }
 
 
@@ -40,3 +48,25 @@ def get_user(db, username: str) -> User:
         error(f'User "{username}" not found!')
 
     return user
+
+
+def print_table(
+    table: Table,
+    rows: Iterable[Iterable[Any]],
+    console: Optional[Console] = None
+):
+    for row in rows:
+        table.add_row(*row)
+
+    (console or rich_console).print(table)
+
+
+def readable_datetime(date_time: Optional[datetime]):
+    return date_time.strftime("%d %B %Y, %H:%M:%S") if date_time else "-"
+
+
+def raise_if_falsy(obj: T, message: str) -> T:
+    if not obj:
+        error(text=message, auto_exit=True)
+
+    return obj

--- a/marzban-cli.py
+++ b/marzban-cli.py
@@ -2,11 +2,13 @@
 import typer
 import readline  # noqa
 import cli.admin
+import cli.user
 import cli.subscription
 
 app = typer.Typer(no_args_is_help=True)
 app.add_typer(cli.admin.app, name="admin")
 app.add_typer(cli.subscription.app, name="subscription")
+app.add_typer(cli.user.app, name="user")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Details:
 - User app added.
 - `user list` and `user set-owner` commands implemented.
 - CLI's user documents generated.

Side notes:
 - utils.py: `print_table` implemented
 - utils.py: `readable_datetime` implemented
 - utils.py: `raise_if_falsy` implemented