### PR TITLE
Adding URL prefix

### DIFF
--- a/config.py
+++ b/config.py
@@ -10,6 +10,7 @@ SQLALCHEMY_DATABASE_URL = config("SQLALCHEMY_DATABASE_URL", default="sqlite:///d
 UVICORN_HOST = config("UVICORN_HOST", default="0.0.0.0")
 UVICORN_PORT = config("UVICORN_PORT", cast=int, default=8000)
 UVICORN_UDS = config("UVICORN_UDS", default=None)
+UVICORN_ROOT_PATH = config("UVICORN_ROOT_PATH," default=None)
 UVICORN_SSL_CERTFILE = config("UVICORN_SSL_CERTFILE", default=None)
 UVICORN_SSL_KEYFILE = config("UVICORN_SSL_KEYFILE", default=None)
 

--- a/config.py
+++ b/config.py
@@ -10,7 +10,7 @@ SQLALCHEMY_DATABASE_URL = config("SQLALCHEMY_DATABASE_URL", default="sqlite:///d
 UVICORN_HOST = config("UVICORN_HOST", default="0.0.0.0")
 UVICORN_PORT = config("UVICORN_PORT", cast=int, default=8000)
 UVICORN_UDS = config("UVICORN_UDS", default=None)
-UVICORN_ROOT_PATH = config("UVICORN_ROOT_PATH," default=None)
+UVICORN_ROOT_PATH = config("UVICORN_ROOT_PATH", default=None)
 UVICORN_SSL_CERTFILE = config("UVICORN_SSL_CERTFILE", default=None)
 UVICORN_SSL_KEYFILE = config("UVICORN_SSL_KEYFILE", default=None)
 

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ from config import (
     UVICORN_HOST,
     UVICORN_PORT,
     UVICORN_UDS,
+    UVICORN_ROOT_PATH,
     UVICORN_SSL_CERTFILE,
     UVICORN_SSL_KEYFILE
 )
@@ -19,6 +20,7 @@ if __name__ == "__main__":
             host=('0.0.0.0' if DEBUG else UVICORN_HOST),
             port=UVICORN_PORT,
             uds=(None if DEBUG else UVICORN_UDS),
+            root_path=UVICORN_ROOT_PATH
             ssl_certfile=UVICORN_SSL_CERTFILE,
             ssl_keyfile=UVICORN_SSL_KEYFILE,
             workers=1,

--- a/main.py
+++ b/main.py
@@ -20,7 +20,7 @@ if __name__ == "__main__":
             host=('0.0.0.0' if DEBUG else UVICORN_HOST),
             port=UVICORN_PORT,
             uds=(None if DEBUG else UVICORN_UDS),
-            root_path=UVICORN_ROOT_PATH
+            root_path=UVICORN_ROOT_PATH,
             ssl_certfile=UVICORN_SSL_CERTFILE,
             ssl_keyfile=UVICORN_SSL_KEYFILE,
             workers=1,


### PR DESCRIPTION
Adding a simple option (and environmental variable) to add a URL prefix using root-path:
> The root_path is a mechanism provided by the ASGI specification (that FastAPI is built on, through Starlette).

[Link to FastAPI documentation](https://fastapi.tiangolo.com/advanced/behind-a-proxy/)

Feel free to edit if needed.