### PR TITLE
fix dictionary keys changed during iteration

### DIFF
--- a/app/jobs/1_start_nodes.py
+++ b/app/jobs/1_start_nodes.py
@@ -23,7 +23,7 @@ def app_shutdown():
 
 
 def reconnect_nodes():
-    for node_id, node in xray.nodes.items():
+    for node_id, node in xray.nodes.copy().items():
         if not node.connected:
             xray.operations.connect_node(node_id, xray.config.include_db_users())
 

--- a/app/jobs/record_usages.py
+++ b/app/jobs/record_usages.py
@@ -132,7 +132,7 @@ def record_usages():
     record_user_usage(xray.api, node_id=0)  # main core
     record_node_usage(xray.api, node_id=0)  # main core
 
-    for node_id, node in xray.nodes.items():
+    for node_id, node in xray.nodes.copy().items():
         if node.connected:
             record_user_usage(node.api, node_id=node_id)
             record_node_usage(node.api, node_id=node_id)

--- a/app/telegram/handlers/admin.py
+++ b/app/telegram/handlers/admin.py
@@ -860,7 +860,7 @@ def confirm_user_command(call: types.CallbackQuery):
         m = bot.edit_message_text(
             '🔄 Restarting XRay core...', call.message.chat.id, call.message.message_id)
         xray.core.restart(xray.config.include_db_users())
-        for node_id, node in xray.nodes.items():
+        for node_id, node in xray.nodes.copy().items():
             if node.connected:
                 xray.operations.restart_node(node_id, xray.config.include_db_users())
         bot.edit_message_text(

--- a/app/views/core.py
+++ b/app/views/core.py
@@ -87,7 +87,7 @@ def restart_core(admin: Admin = Depends(Admin.get_current)):
         raise HTTPException(status_code=403, detail="You're not allowed")
 
     xray.core.restart(xray.config.include_db_users())
-    for node_id, node in xray.nodes.items():
+    for node_id, node in xray.nodes.copy().items():
         if node.connected:
             xray.operations.restart_node(node_id, xray.config.include_db_users())
     return {}
@@ -117,7 +117,7 @@ def get_core_config(payload: dict, admin: Admin = Depends(Admin.get_current)) ->
 
     xray.config = config
     xray.core.restart(xray.config.include_db_users())
-    for node_id, node in xray.nodes.items():
+    for node_id, node in xray.nodes.copy().items():
         if node.connected:
             xray.operations.restart_node(node_id, xray.config.include_db_users())
 

--- a/app/views/user.py
+++ b/app/views/user.py
@@ -214,7 +214,7 @@ def reset_users_data_usage(db: Session = Depends(get_db),
     dbadmin = crud.get_admin(db, admin.username)
     crud.reset_all_users_data_usage(db=db, admin=dbadmin)
     xray.core.restart(xray.config.include_db_users())
-    for node_id, node in xray.nodes.items():
+    for node_id, node in xray.nodes.copy().items():
         if node.connected:
             xray.operations.restart_node(node_id, xray.config.include_db_users())
     return {}

--- a/app/xray/operations.py
+++ b/app/xray/operations.py
@@ -1,4 +1,5 @@
 from sqlalchemy.exc import SQLAlchemyError
+from threading import Thread
 
 from app import logger, xray
 from app.db import GetDB
@@ -7,52 +8,88 @@ from app.db import crud
 from app.db.models import Node as DBNode
 from app.models.node import NodeStatus
 from app.models.user import UserResponse
+from app.models.proxy import ProxyTypes
 from app.utils.concurrency import threaded_function
 from app.xray.node import XRayNode
 from xray_api.types.account import XTLSFlows
 
+def add_inbound_user(dbuser: DBUser, node_id: int, inbound_tag: str, proxy_type: ProxyTypes):
+    user = UserResponse.from_orm(dbuser)
+    inbound = xray.config.inbounds_by_tag.get(inbound_tag, {})
+    try:
+        proxy_settings = user.proxies[proxy_type].dict(no_obj=True)
+    except KeyError:
+        pass
+    account = proxy_type.account_model(email=f"{dbuser.id}.{dbuser.username}", **proxy_settings)
+
+    # XTLS currently only supports transmission methods of TCP and mKCP
+    if inbound.get('network', 'tcp') not in ('tcp', 'kcp') and getattr(account, 'flow', None):
+        account.flow = XTLSFlows.NONE
+
+    if node_id == 0:
+        try:
+            xray.api.add_inbound_user(tag=inbound_tag, user=account)
+        except (xray.exc.EmailExistsError, xray.exc.ConnectionError):
+            pass
+    else:
+        try:
+            xray.nodes[node_id].api.add_inbound_user(tag=inbound_tag, user=account)
+        except (xray.exc.EmailExistsError, xray.exc.ConnectionError):
+            pass
 
 def add_user(dbuser: DBUser):
     user = UserResponse.from_orm(dbuser)
 
+    threads: list[Thread] = []
+
     for proxy_type, inbound_tags in user.inbounds.items():
         for inbound_tag in inbound_tags:
-            inbound = xray.config.inbounds_by_tag.get(inbound_tag, {})
+            job_thread = Thread(target=add_inbound_user, args=(dbuser, 0, inbound_tag, proxy_type), daemon=True)
+            job_thread.start()
+            threads.append(job_thread)
 
-            try:
-                proxy_settings = user.proxies[proxy_type].dict(no_obj=True)
-            except KeyError:
-                pass
-            account = proxy_type.account_model(email=f"{dbuser.id}.{dbuser.username}", **proxy_settings)
-
-            # XTLS currently only supports transmission methods of TCP and mKCP
-            if inbound.get('network', 'tcp') not in ('tcp', 'kcp') and getattr(account, 'flow', None):
-                account.flow = XTLSFlows.NONE
-
-            try:
-                xray.api.add_inbound_user(tag=inbound_tag, user=account)
-            except (xray.exc.EmailExistsError, xray.exc.ConnectionError):
-                pass
-            for node in xray.nodes.values():
-                if node.connected and node.started:
-                    try:
-                        node.api.add_inbound_user(tag=inbound_tag, user=account)
-                    except (xray.exc.EmailExistsError, xray.exc.ConnectionError):
-                        pass
+    for node_id, node in xray.nodes.copy().items():
+        if node.connected and node.started:
+            for proxy_type, inbound_tags in user.inbounds.items():
+                for inbound_tag in inbound_tags:
+                    job_thread = Thread(target=add_inbound_user, args=(dbuser, node_id, inbound_tag, proxy_type), daemon=True)
+                    job_thread.start()
+                    threads.append(job_thread)
+    
+    for job_thread in threads:
+        job_thread.join()
 
 
-def remove_user(dbuser: DBUser):
-    for inbound_tag in xray.config.inbounds_by_tag:
+def remove_inbound_user(dbuser: DBUser, node_id: int, inbound_tag: str):
+    if node_id == 0:
         try:
             xray.api.remove_inbound_user(tag=inbound_tag, email=f"{dbuser.id}.{dbuser.username}")
         except (xray.exc.EmailNotFoundError, xray.exc.ConnectionError):
             pass
-        for node in xray.nodes.values():
-            if node.connected and node.started:
-                try:
-                    node.api.remove_inbound_user(tag=inbound_tag, email=f"{dbuser.id}.{dbuser.username}")
-                except (xray.exc.EmailNotFoundError, xray.exc.ConnectionError):
-                    pass
+    else:
+        try:
+            xray.nodes[node_id].api.remove_inbound_user(tag=inbound_tag, email=f"{dbuser.id}.{dbuser.username}")
+        except (xray.exc.EmailNotFoundError, xray.exc.ConnectionError):
+            pass
+
+def remove_user(dbuser: DBUser):
+    threads: list[Thread] = []
+
+    for inbound_tag in xray.config.inbounds_by_tag:
+        job_thread = Thread(target=remove_inbound_user, args=(dbuser, 0, inbound_tag))
+        job_thread.start()
+        threads.append(job_thread)
+        
+    for node_id, node in xray.nodes.copy().items():
+        if node.connected and node.started:
+            for inbound_tag in xray.config.inbounds_by_tag:
+                job_thread = Thread(target=remove_inbound_user, args=(dbuser, node_id, inbound_tag))
+                job_thread.start()
+                threads.append(job_thread)
+
+    for job_thread in threads:
+        job_thread.join()
+
 
 
 def remove_node(node_id: int):


### PR DESCRIPTION
api connect_node and restart_node may change nodes dictionary by xray.operations.add_node

exception:
Job "reconnect_nodes (trigger: interval[0:00:15], next run at: 2023-06-06 02:10:55 UTC)" raised an exception
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/apscheduler/executors/base.py", line 125, in run_job
    retval = job.func(*job.args, **job.kwargs)
  File "/Users/codetypes/Documents/github/marzban/app/jobs/1_start_nodes.py", line 26, in reconnect_nodes
    for node_id, node in xray.nodes.items():
RuntimeError: dictionary keys changed during iteration