### PR TITLE
Save Items per page selection in localStorage

### DIFF
--- a/app/dashboard/src/components/Pagination.tsx
+++ b/app/dashboard/src/components/Pagination.tsx
@@ -14,6 +14,7 @@ import {
 import { useDashboard } from "contexts/DashboardContext";
 import { ChangeEvent, FC } from "react";
 import { useTranslation } from "react-i18next";
+import { setUsersPerPageLimitSize } from "utils/userPreferenceStorage";
 
 const PrevIcon = chakra(ArrowLongLeftIcon, {
   baseStyle: {
@@ -98,6 +99,7 @@ export const Pagination: FC = () => {
       ...filters,
       limit: parseInt(e.target.value),
     });
+    setUsersPerPageLimitSize(e.target.value);
   };
 
   const { t } = useTranslation();

--- a/app/dashboard/src/contexts/DashboardContext.tsx
+++ b/app/dashboard/src/contexts/DashboardContext.tsx
@@ -2,6 +2,7 @@ import { StatisticsQueryKey } from "components/Statistics";
 import { fetch } from "service/http";
 import { User, UserCreate } from "types/User";
 import { queryClient } from "utils/react-query";
+import { getUsersPerPageLimitSize } from "utils/userPrefrenceStorage";
 import { create } from "zustand";
 import { subscribeWithSelector } from "zustand/middleware";
 
@@ -115,7 +116,11 @@ export const useDashboard = create(
     isShowingNodesUsage: false,
     resetUsageUser: null,
     revokeSubscriptionUser: null,
-    filters: { username: "", limit: 10, sort: "-created_at" },
+    filters: {
+      username: "",
+      limit: getUsersPerPageLimitSize(),
+      sort: "-created_at",
+    },
     inbounds: new Map(),
     isEditingCore: false,
     refetchUsers: () => {

--- a/app/dashboard/src/utils/userPreferenceStorage.ts
+++ b/app/dashboard/src/utils/userPreferenceStorage.ts
@@ -1,0 +1,12 @@
+const NUM_USERS_PER_PAGE_LOCAL_STORAGE_KEY = "marzban-num-users-per-page";
+const NUM_USERS_PER_PAGE_DEFAULT = 10;
+export const getUsersPerPageLimitSize = () => {
+  const numUsersPerPage =
+    localStorage.getItem(NUM_USERS_PER_PAGE_LOCAL_STORAGE_KEY) ||
+    NUM_USERS_PER_PAGE_DEFAULT.toString(); // this catches `null` values
+  return parseInt(numUsersPerPage) || NUM_USERS_PER_PAGE_DEFAULT; // this catches NaN values
+};
+
+export const setUsersPerPageLimitSize = (value: string) => {
+  return localStorage.setItem(NUM_USERS_PER_PAGE_LOCAL_STORAGE_KEY, value);
+};


### PR DESCRIPTION
Hi, thank you for your amazing work

this pr saves the selection of "items per page" dropdown (at the buttom) to the local storage so it's not lost after every refresh.

Sorry for creating this pr before discussing the problem in the issues.
this is something that's been bugging me for the longest time so i thought i should fix it.