### PR TITLE
hot fix: subscription info if revoked

### DIFF
--- a/app/views/subscription.py
+++ b/app/views/subscription.py
@@ -86,4 +86,7 @@ def user_subcription_info(token: str,
     if not dbuser or dbuser.created_at > sub['created_at']:
         return Response(status_code=404)
 
+    elif dbuser.sub_revoked_at and dbuser.sub_revoked_at > sub['created_at']:
+        return Response(status_code=404)
+
     return dbuser


### PR DESCRIPTION
if subscription link revoked and open "/sub/{token}/info" with old token will show the new subscription link and other data

fixed now