### PR TITLE
Back: Explicitly set `nullable=True` on nullable fields of the pydantic models

### DIFF
--- a/app/models/node.py
+++ b/app/models/node.py
@@ -1,8 +1,9 @@
+from enum import Enum
+from typing import List, Optional, Union
+
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
-from pydantic import BaseModel, validator
-from enum import Enum
-from typing import Union, List
+from pydantic import BaseModel, Field, validator
 
 
 class NodeStatus(str, Enum):
@@ -19,7 +20,7 @@ class Node(BaseModel):
     api_port: int = 62051
     certificate: str
 
-    @validator('certificate', pre=True, always=True)
+    @validator("certificate", pre=True, always=True)
     def validate_certificate(cls, v):
         if v is None:
             return v
@@ -28,7 +29,7 @@ class Node(BaseModel):
         try:
             x509.load_pem_x509_certificate(data=v.encode(), backend=default_backend())
         except ValueError:
-            raise ValueError('certificate is not valid')
+            raise ValueError("certificate is not valid")
 
         return v
 
@@ -44,17 +45,17 @@ class NodeCreate(Node):
                 "port": 62050,
                 "api_port": 62051,
                 "add_as_new_host": True,
-                "certificate": "-----BEGIN CERTIFICATE-----\nMIIEnDCCAoQCAQAwDQYJKoZIhvcNAQENBQAwEzERMA8GA1UEAwwIR296YXJnYWgw\nIBcNMjMwMjE5MjMwOTMyWhgPMjEyMzAxMjYyMzA5MzJaMBMxETAPBgNVBAMMCEdv\nemFyZ2FoMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA0BvDh0eU78EJ\n+xzBWUjjMrWf/0rWV5fDl7b4RU8AjeviG1RmEc64ueZ3s6q1LI6DJX1+qGuqDEvp\nmRc09HihO07DyQgQqF38/E4CXshZ2L3UOzsa80lf74dhEqAR/EJQXXMwGSb3T9J9\nseCqCyiEn/JLEGsilDz64cTv8MXMAcjjpdefkFyQP+4hAKQgHbtfJ9KPSu4/lkZR\n/orsjoWGJv4LS0MsXV1t7LB/bNC7qOzlmzrfTMH4EmtmKH8HwhMkL1nUG+vXEfwm\nQg3Ly+yrwKNw9+L7DxbKnoy2Zqp9dN+rzKDgcpHsoIYf0feInUHHlRUu303kAFQN\nGlnzZgD8ulHI1sQLNS3teYpj817G3EXKOhu56MvBehBR9GfvfS1D5D/QvwRfcaZI\nCULBPoGqovhrknbUXt9TEfzc9YnfSzlcJYcH54/aUBVJNs74EK38OQ+JciLnw4qe\ngbXEshaeLgGM3bhXwUhctcmZf5ASWDsAVtEeCXGNK+ua6wlFXKVd0jOt2ZZYG42X\nwrpHCErAWY7AoxHmXlfPcPM0Uu7FuEBP27f8U3N+glG1lWrogNn54j1ZrzQVUVVv\ngog78DrjjzrR0puQ9x9q6FvEUTAaaA06lvi2/6BuwO0jKrHQCP7fFUmRXg5B5lrJ\n9czSDHT9WH9Sc1qdxQTevhc9C/h6MuMCAwEAATANBgkqhkiG9w0BAQ0FAAOCAgEA\nI7aXhLejp53NyuwzmdfeycY373TI4sD3WfPdEB6+FSCX38YghyQl8tkeaHPgPKY5\n+vA+eVxE7E961UNPtJtJg/dzBvoWUroTnpvKjVdDImFaZa/PvUMgSEe8tC3FtB6i\nAp7f0yYOGsFf6oaOxMfs/F0sGflsaVWuiATTsV8Er+uzge77Q8AXzy6spuXg3ALF\n56tqzZY5x/04g1KUQB4JN+7JzipnfSIUof0eAKf9gQbumUU+Q2b32HMC2MOlUjv+\nIl8rJ9cs0zwC1BOmqoS3Ez22dgtT7FucvIJ1MGP8oUAudMmrXDxx/d7CmnD5q1v4\nXFSa6Zv8LPLCz5iMbo0FjNlKyZo3699PtyBFXt3zyfTPmiy19RVGTziHqJ9NR9kW\nkBwvFzIy+qPc/dJAk435hVaV3pRBC7Pl2Y7k/pJxxlC07PkACXuhwtUGhQrHYWkK\niLlV21kNnWuvjS1orTwvuW3aagb6tvEEEmlMhw5a2B8sl71sQ6sxWidgRaOSGW7l\ng1gctfdLMARuV6LkLiGy5k2FGAW/tfepEyySA/N9WhcHg+rZ4/x1thP0eYJPQ2YJ\nAjimHyBb+3tFs7KaOPu9G5xgbQWUWccukMDXqybqiUDSfU/T5/+XM8CKq/Fu0DBu\n3lg0NYigkZFs99lZJ1H4BkMWgL65aybO4XwfZJTGLe0=\n-----END CERTIFICATE-----"
+                "certificate": "-----BEGIN CERTIFICATE-----\nMIIEnDCCAoQCAQAwDQYJKoZIhvcNAQENBQAwEzERMA8GA1UEAwwIR296YXJnYWgw\nIBcNMjMwMjE5MjMwOTMyWhgPMjEyMzAxMjYyMzA5MzJaMBMxETAPBgNVBAMMCEdv\nemFyZ2FoMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA0BvDh0eU78EJ\n+xzBWUjjMrWf/0rWV5fDl7b4RU8AjeviG1RmEc64ueZ3s6q1LI6DJX1+qGuqDEvp\nmRc09HihO07DyQgQqF38/E4CXshZ2L3UOzsa80lf74dhEqAR/EJQXXMwGSb3T9J9\nseCqCyiEn/JLEGsilDz64cTv8MXMAcjjpdefkFyQP+4hAKQgHbtfJ9KPSu4/lkZR\n/orsjoWGJv4LS0MsXV1t7LB/bNC7qOzlmzrfTMH4EmtmKH8HwhMkL1nUG+vXEfwm\nQg3Ly+yrwKNw9+L7DxbKnoy2Zqp9dN+rzKDgcpHsoIYf0feInUHHlRUu303kAFQN\nGlnzZgD8ulHI1sQLNS3teYpj817G3EXKOhu56MvBehBR9GfvfS1D5D/QvwRfcaZI\nCULBPoGqovhrknbUXt9TEfzc9YnfSzlcJYcH54/aUBVJNs74EK38OQ+JciLnw4qe\ngbXEshaeLgGM3bhXwUhctcmZf5ASWDsAVtEeCXGNK+ua6wlFXKVd0jOt2ZZYG42X\nwrpHCErAWY7AoxHmXlfPcPM0Uu7FuEBP27f8U3N+glG1lWrogNn54j1ZrzQVUVVv\ngog78DrjjzrR0puQ9x9q6FvEUTAaaA06lvi2/6BuwO0jKrHQCP7fFUmRXg5B5lrJ\n9czSDHT9WH9Sc1qdxQTevhc9C/h6MuMCAwEAATANBgkqhkiG9w0BAQ0FAAOCAgEA\nI7aXhLejp53NyuwzmdfeycY373TI4sD3WfPdEB6+FSCX38YghyQl8tkeaHPgPKY5\n+vA+eVxE7E961UNPtJtJg/dzBvoWUroTnpvKjVdDImFaZa/PvUMgSEe8tC3FtB6i\nAp7f0yYOGsFf6oaOxMfs/F0sGflsaVWuiATTsV8Er+uzge77Q8AXzy6spuXg3ALF\n56tqzZY5x/04g1KUQB4JN+7JzipnfSIUof0eAKf9gQbumUU+Q2b32HMC2MOlUjv+\nIl8rJ9cs0zwC1BOmqoS3Ez22dgtT7FucvIJ1MGP8oUAudMmrXDxx/d7CmnD5q1v4\nXFSa6Zv8LPLCz5iMbo0FjNlKyZo3699PtyBFXt3zyfTPmiy19RVGTziHqJ9NR9kW\nkBwvFzIy+qPc/dJAk435hVaV3pRBC7Pl2Y7k/pJxxlC07PkACXuhwtUGhQrHYWkK\niLlV21kNnWuvjS1orTwvuW3aagb6tvEEEmlMhw5a2B8sl71sQ6sxWidgRaOSGW7l\ng1gctfdLMARuV6LkLiGy5k2FGAW/tfepEyySA/N9WhcHg+rZ4/x1thP0eYJPQ2YJ\nAjimHyBb+3tFs7KaOPu9G5xgbQWUWccukMDXqybqiUDSfU/T5/+XM8CKq/Fu0DBu\n3lg0NYigkZFs99lZJ1H4BkMWgL65aybO4XwfZJTGLe0=\n-----END CERTIFICATE-----",
             }
         }
 
 
 class NodeModify(Node):
-    name: str = None
-    address: str = None
-    port: int = None
-    api_port: int = None
-    certificate: str = None
+    name: Optional[str] = Field(None, nullable=True)
+    address: Optional[str] = Field(None, nullable=True)
+    port: Optional[int] = Field(None, nullable=True)
+    api_port: Optional[int] = Field(None, nullable=True)
+    certificate: Optional[str] = Field(None, nullable=True)
 
     class Config:
         schema_extra = {
@@ -63,23 +64,23 @@ class NodeModify(Node):
                 "address": "192.168.1.1",
                 "port": 62050,
                 "api_port": 62051,
-                "certificate": "-----BEGIN CERTIFICATE-----\nMIIEnDCCAoQCAQAwDQYJKoZIhvcNAQENBQAwEzERMA8GA1UEAwwIR296YXJnYWgw\nIBcNMjMwMjE5MjMwOTMyWhgPMjEyMzAxMjYyMzA5MzJaMBMxETAPBgNVBAMMCEdv\nemFyZ2FoMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA0BvDh0eU78EJ\n+xzBWUjjMrWf/0rWV5fDl7b4RU8AjeviG1RmEc64ueZ3s6q1LI6DJX1+qGuqDEvp\nmRc09HihO07DyQgQqF38/E4CXshZ2L3UOzsa80lf74dhEqAR/EJQXXMwGSb3T9J9\nseCqCyiEn/JLEGsilDz64cTv8MXMAcjjpdefkFyQP+4hAKQgHbtfJ9KPSu4/lkZR\n/orsjoWGJv4LS0MsXV1t7LB/bNC7qOzlmzrfTMH4EmtmKH8HwhMkL1nUG+vXEfwm\nQg3Ly+yrwKNw9+L7DxbKnoy2Zqp9dN+rzKDgcpHsoIYf0feInUHHlRUu303kAFQN\nGlnzZgD8ulHI1sQLNS3teYpj817G3EXKOhu56MvBehBR9GfvfS1D5D/QvwRfcaZI\nCULBPoGqovhrknbUXt9TEfzc9YnfSzlcJYcH54/aUBVJNs74EK38OQ+JciLnw4qe\ngbXEshaeLgGM3bhXwUhctcmZf5ASWDsAVtEeCXGNK+ua6wlFXKVd0jOt2ZZYG42X\nwrpHCErAWY7AoxHmXlfPcPM0Uu7FuEBP27f8U3N+glG1lWrogNn54j1ZrzQVUVVv\ngog78DrjjzrR0puQ9x9q6FvEUTAaaA06lvi2/6BuwO0jKrHQCP7fFUmRXg5B5lrJ\n9czSDHT9WH9Sc1qdxQTevhc9C/h6MuMCAwEAATANBgkqhkiG9w0BAQ0FAAOCAgEA\nI7aXhLejp53NyuwzmdfeycY373TI4sD3WfPdEB6+FSCX38YghyQl8tkeaHPgPKY5\n+vA+eVxE7E961UNPtJtJg/dzBvoWUroTnpvKjVdDImFaZa/PvUMgSEe8tC3FtB6i\nAp7f0yYOGsFf6oaOxMfs/F0sGflsaVWuiATTsV8Er+uzge77Q8AXzy6spuXg3ALF\n56tqzZY5x/04g1KUQB4JN+7JzipnfSIUof0eAKf9gQbumUU+Q2b32HMC2MOlUjv+\nIl8rJ9cs0zwC1BOmqoS3Ez22dgtT7FucvIJ1MGP8oUAudMmrXDxx/d7CmnD5q1v4\nXFSa6Zv8LPLCz5iMbo0FjNlKyZo3699PtyBFXt3zyfTPmiy19RVGTziHqJ9NR9kW\nkBwvFzIy+qPc/dJAk435hVaV3pRBC7Pl2Y7k/pJxxlC07PkACXuhwtUGhQrHYWkK\niLlV21kNnWuvjS1orTwvuW3aagb6tvEEEmlMhw5a2B8sl71sQ6sxWidgRaOSGW7l\ng1gctfdLMARuV6LkLiGy5k2FGAW/tfepEyySA/N9WhcHg+rZ4/x1thP0eYJPQ2YJ\nAjimHyBb+3tFs7KaOPu9G5xgbQWUWccukMDXqybqiUDSfU/T5/+XM8CKq/Fu0DBu\n3lg0NYigkZFs99lZJ1H4BkMWgL65aybO4XwfZJTGLe0=\n-----END CERTIFICATE-----"
+                "certificate": "-----BEGIN CERTIFICATE-----\nMIIEnDCCAoQCAQAwDQYJKoZIhvcNAQENBQAwEzERMA8GA1UEAwwIR296YXJnYWgw\nIBcNMjMwMjE5MjMwOTMyWhgPMjEyMzAxMjYyMzA5MzJaMBMxETAPBgNVBAMMCEdv\nemFyZ2FoMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEA0BvDh0eU78EJ\n+xzBWUjjMrWf/0rWV5fDl7b4RU8AjeviG1RmEc64ueZ3s6q1LI6DJX1+qGuqDEvp\nmRc09HihO07DyQgQqF38/E4CXshZ2L3UOzsa80lf74dhEqAR/EJQXXMwGSb3T9J9\nseCqCyiEn/JLEGsilDz64cTv8MXMAcjjpdefkFyQP+4hAKQgHbtfJ9KPSu4/lkZR\n/orsjoWGJv4LS0MsXV1t7LB/bNC7qOzlmzrfTMH4EmtmKH8HwhMkL1nUG+vXEfwm\nQg3Ly+yrwKNw9+L7DxbKnoy2Zqp9dN+rzKDgcpHsoIYf0feInUHHlRUu303kAFQN\nGlnzZgD8ulHI1sQLNS3teYpj817G3EXKOhu56MvBehBR9GfvfS1D5D/QvwRfcaZI\nCULBPoGqovhrknbUXt9TEfzc9YnfSzlcJYcH54/aUBVJNs74EK38OQ+JciLnw4qe\ngbXEshaeLgGM3bhXwUhctcmZf5ASWDsAVtEeCXGNK+ua6wlFXKVd0jOt2ZZYG42X\nwrpHCErAWY7AoxHmXlfPcPM0Uu7FuEBP27f8U3N+glG1lWrogNn54j1ZrzQVUVVv\ngog78DrjjzrR0puQ9x9q6FvEUTAaaA06lvi2/6BuwO0jKrHQCP7fFUmRXg5B5lrJ\n9czSDHT9WH9Sc1qdxQTevhc9C/h6MuMCAwEAATANBgkqhkiG9w0BAQ0FAAOCAgEA\nI7aXhLejp53NyuwzmdfeycY373TI4sD3WfPdEB6+FSCX38YghyQl8tkeaHPgPKY5\n+vA+eVxE7E961UNPtJtJg/dzBvoWUroTnpvKjVdDImFaZa/PvUMgSEe8tC3FtB6i\nAp7f0yYOGsFf6oaOxMfs/F0sGflsaVWuiATTsV8Er+uzge77Q8AXzy6spuXg3ALF\n56tqzZY5x/04g1KUQB4JN+7JzipnfSIUof0eAKf9gQbumUU+Q2b32HMC2MOlUjv+\nIl8rJ9cs0zwC1BOmqoS3Ez22dgtT7FucvIJ1MGP8oUAudMmrXDxx/d7CmnD5q1v4\nXFSa6Zv8LPLCz5iMbo0FjNlKyZo3699PtyBFXt3zyfTPmiy19RVGTziHqJ9NR9kW\nkBwvFzIy+qPc/dJAk435hVaV3pRBC7Pl2Y7k/pJxxlC07PkACXuhwtUGhQrHYWkK\niLlV21kNnWuvjS1orTwvuW3aagb6tvEEEmlMhw5a2B8sl71sQ6sxWidgRaOSGW7l\ng1gctfdLMARuV6LkLiGy5k2FGAW/tfepEyySA/N9WhcHg+rZ4/x1thP0eYJPQ2YJ\nAjimHyBb+3tFs7KaOPu9G5xgbQWUWccukMDXqybqiUDSfU/T5/+XM8CKq/Fu0DBu\n3lg0NYigkZFs99lZJ1H4BkMWgL65aybO4XwfZJTGLe0=\n-----END CERTIFICATE-----",
             }
         }
 
 
 class NodeResponse(Node):
     id: int
-    xray_version: Union[str, None]
+    xray_version: Optional[str]
     status: NodeStatus
-    message: Union[str, None]
+    message: Optional[str]
 
     class Config:
         orm_mode = True
 
 
 class NodeUsageResponse(BaseModel):
-    node_id: Union[int, None]
+    node_id: Optional[int]
     node_name: str
     uplink: int
     downlink: int

--- a/app/models/proxy.py
+++ b/app/models/proxy.py
@@ -1,14 +1,19 @@
 import json
 from enum import Enum
-from typing import List, Union
+from typing import Optional, Union
 from uuid import UUID, uuid4
 
 from pydantic import BaseModel, Field, validator
 
 from app.utils.system import random_password
-from xray_api.types.account import (ShadowsocksAccount, ShadowsocksMethods,
-                                    TrojanAccount, VLESSAccount, VMessAccount,
-                                    XTLSFlows)
+from xray_api.types.account import (
+    ShadowsocksAccount,
+    ShadowsocksMethods,
+    TrojanAccount,
+    VLESSAccount,
+    VMessAccount,
+    XTLSFlows,
+)
 
 
 class ProxyTypes(str, Enum):
@@ -90,27 +95,33 @@ class ProxyHostSecurity(str, Enum):
     tls = "tls"
 
 
-ProxyHostALPN = Enum('ProxyHostALPN', {
-    "none": "",
-    "h2": "h2",
-    "http/1.1": "http/1.1",
-    "h2,http/1.1": "h2,http/1.1",
-})
+ProxyHostALPN = Enum(
+    "ProxyHostALPN",
+    {
+        "none": "",
+        "h2": "h2",
+        "http/1.1": "http/1.1",
+        "h2,http/1.1": "h2,http/1.1",
+    },
+)
 
 
-ProxyHostFingerprint = Enum('ProxyHostFingerprint', {
-    "none": "",
-    "chrome": "chrome",
-    "firefox": "firefox",
-    "safari": "safari",
-    "ios": "ios",
-    "android": "android",
-    "edge": "edge",
-    "360": "360",
-    "qq": "qq",
-    "random": "random",
-    "randomized": "randomized",
-})
+ProxyHostFingerprint = Enum(
+    "ProxyHostFingerprint",
+    {
+        "none": "",
+        "chrome": "chrome",
+        "firefox": "firefox",
+        "safari": "safari",
+        "ios": "ios",
+        "android": "android",
+        "edge": "edge",
+        "360": "360",
+        "qq": "qq",
+        "random": "random",
+        "randomized": "randomized",
+    },
+)
 
 
 class FormatVariables(dict):
@@ -121,9 +132,9 @@ class FormatVariables(dict):
 class ProxyHost(BaseModel):
     remark: str
     address: str
-    port: Union[int, None] = None
-    sni: Union[str, None] = None
-    host: Union[str, None] = None
+    port: Optional[int] = Field(None, nullable=True)
+    sni: Optional[str] = Field(None, nullable=True)
+    host: Optional[str] = Field(None, nullable=True)
     security: ProxyHostSecurity = ProxyHostSecurity.inbound_default
     alpn: ProxyHostALPN = ProxyHostALPN.none
     fingerprint: ProxyHostFingerprint = ProxyHostFingerprint.none
@@ -131,21 +142,21 @@ class ProxyHost(BaseModel):
     class Config:
         orm_mode = True
 
-    @validator('remark', pre=False, always=True)
+    @validator("remark", pre=False, always=True)
     def validate_remark(cls, v):
         try:
             v.format_map(FormatVariables())
         except ValueError as exc:
-            raise ValueError('Invalid formatting variables')
+            raise ValueError("Invalid formatting variables")
 
         return v
 
-    @validator('address', pre=False, always=True)
+    @validator("address", pre=False, always=True)
     def validate_address(cls, v):
         try:
             v.format_map(FormatVariables())
         except ValueError as exc:
-            raise ValueError('Invalid formatting variables')
+            raise ValueError("Invalid formatting variables")
 
         return v
 

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,7 +1,7 @@
 import re
 from datetime import datetime
 from enum import Enum
-from typing import Dict, List, Union
+from typing import Dict, List, Optional, Union
 
 from pydantic import BaseModel, Field, validator
 
@@ -12,7 +12,7 @@ from app.utils.share import generate_v2ray_links
 from config import XRAY_SUBSCRIPTION_URL_PREFIX
 from xray_api.types.account import Account
 
-USERNAME_REGEXP = re.compile(r'^(?=\w{3,32}\b)[a-zA-Z0-9]+(?:_[a-zA-Z0-9]+)*$')
+USERNAME_REGEXP = re.compile(r"^(?=\w{3,32}\b)[a-zA-Z0-9]+(?:_[a-zA-Z0-9]+)*$")
 
 
 class ReminderType(str, Enum):
@@ -42,30 +42,39 @@ class UserDataLimitResetStrategy(str, Enum):
 
 class User(BaseModel):
     proxies: Dict[ProxyTypes, ProxySettings] = {}
-    expire: int = None
-    data_limit: Union[None, int] = Field(ge=0, default=None, description="data_limit can be 0 or greater")
-    data_limit_reset_strategy: UserDataLimitResetStrategy = UserDataLimitResetStrategy.no_reset
+    expire: Optional[int] = Field(None, nullable=True)
+    data_limit: Optional[int] = Field(
+        ge=0, default=None, description="data_limit can be 0 or greater"
+    )
+    data_limit_reset_strategy: UserDataLimitResetStrategy = (
+        UserDataLimitResetStrategy.no_reset
+    )
     inbounds: Dict[ProxyTypes, List[str]] = {}
-    note: str = None
-    sub_updated_at: datetime = None
-    sub_last_user_agent: str = None
+    note: Optional[str] = Field(None, nullable=True)
+    sub_updated_at: Optional[datetime] = Field(None, nullable=True)
+    sub_last_user_agent: Optional[str] = Field(None, nullable=True)
 
-    @validator('proxies', pre=True, always=True)
+    @validator("proxies", pre=True, always=True)
     def validate_proxies(cls, v, values, **kwargs):
         if not v:
             raise ValueError("Each user needs at least one proxy")
-        return {proxy_type: ProxySettings.from_dict(proxy_type, v.get(proxy_type, {})) for proxy_type in v}
+        return {
+            proxy_type: ProxySettings.from_dict(proxy_type, v.get(proxy_type, {}))
+            for proxy_type in v
+        }
 
-    @validator('username', check_fields=False)
+    @validator("username", check_fields=False)
     def validate_username(cls, v):
         if not USERNAME_REGEXP.match(v):
-            raise ValueError('Username only can be 3 to 32 characters and contain a-z, 0-9, and underscores in between.')
+            raise ValueError(
+                "Username only can be 3 to 32 characters and contain a-z, 0-9, and underscores in between."
+            )
         return v
 
-    @validator('note', check_fields=False)
+    @validator("note", check_fields=False)
     def validate_note(cls, v):
         if v and len(v) > 500:
-            raise ValueError('User\'s note can be a maximum of 500 character')
+            raise ValueError("User's note can be a maximum of 500 character")
         return v
 
 
@@ -77,25 +86,17 @@ class UserCreate(User):
             "example": {
                 "username": "user1234",
                 "proxies": {
-                    "vmess": {
-                        "id": "35e4e39c-7d5c-4f4b-8b71-558e4f37ff53"
-                    },
-                    "vless": {}
+                    "vmess": {"id": "35e4e39c-7d5c-4f4b-8b71-558e4f37ff53"},
+                    "vless": {},
                 },
-                "inbounds":  {
-                    "vmess": [
-                        "VMess TCP",
-                        "VMess Websocket"
-                    ],
-                    "vless": [
-                        "VLESS TCP REALITY",
-                        "VLESS GRPC REALITY"
-                    ]
+                "inbounds": {
+                    "vmess": ["VMess TCP", "VMess Websocket"],
+                    "vless": ["VLESS TCP REALITY", "VLESS GRPC REALITY"],
                 },
                 "expire": 0,
                 "data_limit": 0,
                 "data_limit_reset_strategy": "no_reset",
-                "note": ""
+                "note": "",
             }
         }
 
@@ -105,14 +106,14 @@ class UserCreate(User):
         for proxy_type in self.proxies:
             excluded[proxy_type] = []
             for inbound in xray.config.inbounds_by_protocol.get(proxy_type, []):
-                if not inbound['tag'] in self.inbounds.get(proxy_type, []):
-                    excluded[proxy_type].append(inbound['tag'])
+                if not inbound["tag"] in self.inbounds.get(proxy_type, []):
+                    excluded[proxy_type].append(inbound["tag"])
 
         return excluded
 
-    @validator('inbounds', pre=True, always=True)
+    @validator("inbounds", pre=True, always=True)
     def validate_inbounds(cls, inbounds, values, **kwargs):
-        proxies = values.get('proxies', [])
+        proxies = values.get("proxies", [])
 
         # delete inbounds that are for protocols not activated
         for proxy_type in inbounds.copy():
@@ -132,7 +133,10 @@ class UserCreate(User):
                         raise ValueError(f"Inbound {tag} doesn't exist")
 
             else:
-                inbounds[proxy_type] = [i['tag'] for i in xray.config.inbounds_by_protocol.get(proxy_type, [])]
+                inbounds[proxy_type] = [
+                    i["tag"]
+                    for i in xray.config.inbounds_by_protocol.get(proxy_type, [])
+                ]
 
         return inbounds
 
@@ -145,26 +149,18 @@ class UserModify(User):
         schema_extra = {
             "example": {
                 "proxies": {
-                    "vmess": {
-                        "id": "35e4e39c-7d5c-4f4b-8b71-558e4f37ff53"
-                    },
-                    "vless": {}
+                    "vmess": {"id": "35e4e39c-7d5c-4f4b-8b71-558e4f37ff53"},
+                    "vless": {},
                 },
-                "inbounds":  {
-                    "vmess": [
-                        "VMess TCP",
-                        "VMess Websocket"
-                    ],
-                    "vless": [
-                        "VLESS TCP REALITY",
-                        "VLESS GRPC REALITY"
-                    ]
+                "inbounds": {
+                    "vmess": ["VMess TCP", "VMess Websocket"],
+                    "vless": ["VLESS TCP REALITY", "VLESS GRPC REALITY"],
                 },
                 "expire": 0,
                 "data_limit": 0,
                 "data_limit_reset_strategy": "no_reset",
                 "status": "active",
-                "note": ""
+                "note": "",
             }
         }
 
@@ -174,12 +170,12 @@ class UserModify(User):
         for proxy_type in self.inbounds:
             excluded[proxy_type] = []
             for inbound in xray.config.inbounds_by_protocol.get(proxy_type, []):
-                if not inbound['tag'] in self.inbounds.get(proxy_type, []):
-                    excluded[proxy_type].append(inbound['tag'])
+                if not inbound["tag"] in self.inbounds.get(proxy_type, []):
+                    excluded[proxy_type].append(inbound["tag"])
 
         return excluded
 
-    @validator('inbounds', pre=True, always=True)
+    @validator("inbounds", pre=True, always=True)
     def validate_inbounds(cls, inbounds, values, **kwargs):
         # check with inbounds, "proxies" is optional on modifying
         # so inbounds particularly can be modified
@@ -194,9 +190,12 @@ class UserModify(User):
 
         return inbounds
 
-    @validator('proxies', pre=True, always=True)
+    @validator("proxies", pre=True, always=True)
     def validate_proxies(cls, v):
-        return {proxy_type: ProxySettings.from_dict(proxy_type, v.get(proxy_type, {})) for proxy_type in v}
+        return {
+            proxy_type: ProxySettings.from_dict(proxy_type, v.get(proxy_type, {}))
+            for proxy_type in v
+        }
 
 
 class UserResponse(User):
@@ -206,29 +205,29 @@ class UserResponse(User):
     lifetime_used_traffic: int = 0
     created_at: datetime
     links: List[str] = []
-    subscription_url: str = ''
+    subscription_url: str = ""
     proxies: dict
     excluded_inbounds: Dict[ProxyTypes, List[str]] = {}
 
     class Config:
         orm_mode = True
 
-    @validator('links', pre=False, always=True)
+    @validator("links", pre=False, always=True)
     def validate_links(cls, v, values, **kwargs):
         if not v:
-            return generate_v2ray_links(values.get('proxies', {}),
-                                        values.get('inbounds', {}),
-                                        extra_data=values)
+            return generate_v2ray_links(
+                values.get("proxies", {}), values.get("inbounds", {}), extra_data=values
+            )
         return v
 
-    @validator('subscription_url', pre=False, always=True)
+    @validator("subscription_url", pre=False, always=True)
     def validate_subscription_url(cls, v, values, **kwargs):
         if not v:
-            token = create_subscription_token(values['username'])
-            return f'{XRAY_SUBSCRIPTION_URL_PREFIX}/sub/{token}'
+            token = create_subscription_token(values["username"])
+            return f"{XRAY_SUBSCRIPTION_URL_PREFIX}/sub/{token}"
         return v
 
-    @validator('proxies', pre=True, always=True)
+    @validator("proxies", pre=True, always=True)
     def validate_proxies(cls, v, values, **kwargs):
         if isinstance(v, list):
             v = {p.type: p.settings for p in v}

--- a/app/models/user_template.py
+++ b/app/models/user_template.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Union
+from typing import Dict, List, Optional, Union
 
 from pydantic import BaseModel, Field, validator
 
@@ -7,12 +7,15 @@ from app.models.proxy import ProxyTypes
 
 
 class UserTemplate(BaseModel):
-    name: Union[str, None] = None
-    data_limit: Union[int, None] = Field(ge=0, default=None, description="data_limit can be 0 or greater")
-    expire_duration: Union[int, None] = Field(
-        ge=0, default=None, description="expire_duration can be 0 or greater in seconds")
-    username_prefix: Union[str, None] = Field(max_length=20, min_length=1, default=None)
-    username_suffix: Union[str, None] = Field(max_length=20, min_length=1, default=None)
+    name: Optional[str] = Field(None, nullable=True)
+    data_limit: Optional[int] = Field(
+        ge=0, default=None, description="data_limit can be 0 or greater"
+    )
+    expire_duration: Optional[int] = Field(
+        ge=0, default=None, description="expire_duration can be 0 or greater in seconds"
+    )
+    username_prefix: Optional[str] = Field(max_length=20, min_length=1, default=None)
+    username_suffix: Optional[str] = Field(max_length=20, min_length=1, default=None)
 
     inbounds: Dict[ProxyTypes, List[str]] = {}
 
@@ -22,16 +25,9 @@ class UserTemplateCreate(UserTemplate):
         schema_extra = {
             "example": {
                 "name": "my template 1",
-                "inbounds": {
-                    "vmess": [
-                        "VMESS_INBOUND"
-                    ],
-                    "vless": [
-                        "VLESS_INBOUND"
-                    ]
-                },
+                "inbounds": {"vmess": ["VMESS_INBOUND"], "vless": ["VLESS_INBOUND"]},
                 "data_limit": 0,
-                "expire_duration": 0
+                "expire_duration": 0,
             }
         }
 
@@ -41,16 +37,9 @@ class UserTemplateModify(UserTemplate):
         schema_extra = {
             "example": {
                 "name": "my template 1",
-                "inbounds": {
-                    "vmess": [
-                        "VMESS_INBOUND"
-                    ],
-                    "vless": [
-                        "VLESS_INBOUND"
-                    ]
-                },
+                "inbounds": {"vmess": ["VMESS_INBOUND"], "vless": ["VLESS_INBOUND"]},
                 "data_limit": 0,
-                "expire_duration": 0
+                "expire_duration": 0,
             }
         }
 
@@ -64,11 +53,11 @@ class UserTemplateResponse(UserTemplate):
         inbound_tags = [i.tag for i in v]
         for protocol, inbounds in xray.config.inbounds_by_protocol.items():
             for inbound in inbounds:
-                if inbound['tag'] in inbound_tags:
+                if inbound["tag"] in inbound_tags:
                     if protocol in final:
-                        final[protocol].append(inbound['tag'])
+                        final[protocol].append(inbound["tag"])
                     else:
-                        final[protocol] = [inbound['tag']]
+                        final[protocol] = [inbound["tag"]]
         return final
 
     class Config:


### PR DESCRIPTION
Per [this answer](https://github.com/openapi-generators/openapi-python-client/issues/698#issuecomment-1311936243) there is a bug in pydantic and the openapi schema generator can't identify some of the nullable fields in the models. so we have to set them explicitly, so the schema would be generated correctly and automatic openapi code genrators like [openapi-python-client](https://github.com/openapi-generators/openapi-python-client) work as expected.

