### PR TITLE
Refining xtls-rprx-vision Flow Selection in TCP Configurations

### DIFF
--- a/app/utils/share.py
+++ b/app/utils/share.py
@@ -104,8 +104,8 @@ class V2rayShareLink(str):
             "type": net,
             "host": host,
             "headerType": type
-        }
-        if flow and net in ('tcp', 'kcp'):
+        }             
+        if flow and net == 'tcp' and tls == 'reality':
             payload['flow'] = flow
 
         if net == 'grpc':

--- a/app/xray/config.py
+++ b/app/xray/config.py
@@ -289,8 +289,8 @@ class XRayConfig(dict):
         inbound = self.inbounds_by_tag.get(inbound_tag, {})
         client = {"email": email, **settings}
 
-        # XTLS currently only supports transmission methods of TCP and mKCP
-        if inbound.get('network', 'tcp') not in ('tcp', 'kcp') and client.get('flow'):
+        # Flow only for Reality and TCP. Xray 1.8.0+
+        if inbound.get('network') != 'tcp' or inbound.get('tls') != 'reality' and client.get('flow'):
             del client['flow']
 
         try:

--- a/app/xray/operations.py
+++ b/app/xray/operations.py
@@ -58,8 +58,8 @@ def add_user(dbuser: "DBUser"):
                 pass
             account = proxy_type.account_model(email=email, **proxy_settings)
 
-            # XTLS currently only supports transmission methods of TCP and mKCP
-            if inbound.get('network', 'tcp') not in ('tcp', 'kcp') and getattr(account, 'flow', None):
+            # Flow only for Reality and TCP. Xray 1.8.0+
+            if inbound.get('network') != 'tcp' or inbound.get('tls') != 'reality' and getattr(account, 'flow', None):
                 account.flow = XTLSFlows.NONE
 
             _add_user_to_inbound(xray.api, inbound_tag, account)  # main core
@@ -94,8 +94,8 @@ def update_user(dbuser: "DBUser"):
                 pass
             account = proxy_type.account_model(email=email, **proxy_settings)
 
-            # XTLS currently only supports transmission methods of TCP and mKCP
-            if inbound.get('network', 'tcp') not in ('tcp', 'kcp') and getattr(account, 'flow', None):
+            # Flow only for Reality and TCP. Xray 1.8.0+
+            if inbound.get('network') != 'tcp' or inbound.get('tls') != 'reality' and getattr(account, 'flow', None):
                 account.flow = XTLSFlows.NONE
 
             _alter_inbound_user(xray.api, inbound_tag, account)  # main core


### PR DESCRIPTION
If we select "xtls-rprx-vision" as the flow, it was [previously ](https://github.com/Gozargah/Marzban/issues/478)enabled for all TCP configurations in vless, regardless of whether they were using "reality" or not. However, I have made modifications to the code to ensure that it is now exclusively applied to Reality + TCP configurations, excluding other types such as TCP + HTTP or TCP + TLS.
