### PR TITLE
Added the ability to use "/usage" for admins to forward information to user

### DIFF
--- a/app/telegram/handlers/admin.py
+++ b/app/telegram/handlers/admin.py
@@ -1965,7 +1965,7 @@ def confirm_user_command(call: types.CallbackQuery):
                 pass
 
 
-@bot.message_handler(func=lambda message: True, is_admin=True)
+@bot.message_handler(func=lambda message: "/usage" not in message.text, is_admin=True)
 def search(message: types.Message):
     with GetDB() as db:
         db_user = crud.get_user(db, message.text)


### PR DESCRIPTION
Added the ability to use "/usage" for admins to forward information to a user or friends without revealing unnecessary data

I often use “/usage” from another account to send information to employees or the user about his tariff limit. This is not entirely convenient, and there is no desire to disclose the data of its Subscription URL. Perhaps this command will be useful to someone, in particular to me it’s true