### PR TITLE
add max early data for sing box sub

### DIFF
--- a/app/telegram/handlers/admin.py
+++ b/app/telegram/handlers/admin.py
@@ -72,8 +72,8 @@ def get_system_info():
         total_users=total_users,
         active_users=users_active,
         deactivate_users=total_users - users_active,
-        up_speed=readable_size(realtime_bandwidth().outgoing_bytes),
-        down_speed=readable_size(realtime_bandwidth().outgoing_bytes)
+        up_speed = readable_size(realtime_bandwidth().outgoing_bytes),
+        down_speed = readable_size(realtime_bandwidth().incoming_bytes)
     )
 
 

--- a/app/utils/share.py
+++ b/app/utils/share.py
@@ -651,7 +651,7 @@ class SingBoxConfiguration(str):
                 if method:
                     transport_config['method'] = method
                 if host:
-                    transport_config['headers'] = {'Host': host}
+                    transport_config["host"] = [host]
                 if idle_timeout:
                     transport_config['idle_timeout'] = idle_timeout
                 if ping_timeout:


### PR DESCRIPTION
old version:
```
"transport": {
        "type": "ws",
        "path": "/test/path?ed=2048",
        "headers": {
          "Host": "YOURDOMAINSERVER"
        }
      }
```
new version:
```
"transport": {
        "type": "ws",
        "path": "/test/path",
        "max_early_data": "2048",
        "early_data_header_name": "Sec-WebSocket-Protocol",
        "headers": {
          "Host": "YOURDOMAINSERVER"
        }
      }
```