### PR TITLE
Singbox mux

### DIFF
--- a/app/telegram/handlers/admin.py
+++ b/app/telegram/handlers/admin.py
@@ -72,8 +72,8 @@ def get_system_info():
         total_users=total_users,
         active_users=users_active,
         deactivate_users=total_users - users_active,
-        up_speed=readable_size(realtime_bandwidth().outgoing_bytes),
-        down_speed=readable_size(realtime_bandwidth().outgoing_bytes)
+        up_speed = readable_size(realtime_bandwidth().outgoing_bytes),
+        down_speed = readable_size(realtime_bandwidth().incoming_bytes)
     )
 
 

--- a/app/templates/singbox/mux_config.json
+++ b/app/templates/singbox/mux_config.json
@@ -1,0 +1,5 @@
+{
+    "enabled": false,
+    "protocol": "smux",
+    "max_streams": 8
+}

--- a/app/utils/share.py
+++ b/app/utils/share.py
@@ -651,7 +651,7 @@ class SingBoxConfiguration(str):
                 if method:
                     transport_config['method'] = method
                 if host:
-                    transport_config['headers'] = {'Host': host}
+                    transport_config["host"] = [host]
                 if idle_timeout:
                     transport_config['idle_timeout'] = idle_timeout
                 if ping_timeout:

--- a/app/utils/share.py
+++ b/app/utils/share.py
@@ -18,7 +18,7 @@ from app.utils.system import get_public_ip, readable_size
 if TYPE_CHECKING:
     from app.models.user import UserResponse
 
-from config import CLASH_SUBSCRIPTION_TEMPLATE, SINGBOX_SUBSCRIPTION_TEMPLATE
+from config import CLASH_SUBSCRIPTION_TEMPLATE, SINGBOX_SUBSCRIPTION_TEMPLATE, SINGBOX_MUX_CONFIGURATION
 
 SERVER_IP = get_public_ip()
 
@@ -576,6 +576,8 @@ class SingBoxConfiguration(str):
     def __init__(self):
         template = render_template(SINGBOX_SUBSCRIPTION_TEMPLATE)
         self.config = json.loads(template)
+        mux_template = render_template(SINGBOX_MUX_CONFIGURATION)
+        self.mux_config = json.loads(mux_template)
 
     def add_outbound(self, outbound_data):
         self.config["outbounds"].append(outbound_data)
@@ -737,6 +739,8 @@ class SingBoxConfiguration(str):
             config['tls'] = self.tls_config(sni=sni, fp=fp, tls=tls,
                                             pbk=pbk, sid=sid, alpn=alpn,
                                             ais=ais)
+            
+        config['multiplex'] = self.mux_config
 
         return config
 

--- a/config.py
+++ b/config.py
@@ -48,6 +48,7 @@ CLASH_SUBSCRIPTION_TEMPLATE = config("CLASH_SUBSCRIPTION_TEMPLATE", default="cla
 SUBSCRIPTION_PAGE_TEMPLATE = config("SUBSCRIPTION_PAGE_TEMPLATE", default="subscription/index.html")
 HOME_PAGE_TEMPLATE = config("HOME_PAGE_TEMPLATE", default="home/index.html")
 SINGBOX_SUBSCRIPTION_TEMPLATE = config("SINGBOX_SUBSCRIPTION_TEMPLATE", default="singbox/default.json")
+SINGBOX_MUX_CONFIGURATION = config("SINGBOX_MUX_CONFIGURATION", default="singbox/mux_config.json")
 
 
 # USERNAME: PASSWORD


### PR DESCRIPTION
The _SINGBOX_MUX_CONFIGURATION_ settings file is taken from the environment like below:
```
SINGBOX_MUX_CONFIGURATION = "templates/singbox/mux_conf.json
```

And finally adds this configuration to all outbound

```
 "multiplex": {
    "enabled": false,
    "protocol": "smux",
    "max_streams": 8
  }
```

[Reference](https://sing-box.sagernet.org/configuration/shared/multiplex/)