### PR TITLE
[Feature] Enable or Disable Mux for specific client

### DIFF
--- a/app/subscription/singbox.py
+++ b/app/subscription/singbox.py
@@ -179,7 +179,8 @@ class SingBoxConfiguration(str):
                                             ais=ais)
 
         config['multiplex'] = self.mux_config
-        config['multiplex']["enabled"] = mux_enable
+        if config['multiplex']["enabled"]:
+            config['multiplex']["enabled"] = mux_enable
 
         return config
 

--- a/app/subscription/v2ray.py
+++ b/app/subscription/v2ray.py
@@ -612,6 +612,7 @@ class V2rayJsonConfig(str):
         )
 
         outbound["mux"] = self.mux_config
-        outbound["mux"]["enabled"] = bool(inbound.get('mux_enable', False))
+        if outbound["mux"]["enabled"]:
+            outbound["mux"]["enabled"] = bool(inbound.get('mux_enable', False))
 
         self.add_config(remarks=remark, outbounds=outbounds)


### PR DESCRIPTION
Fixes this https://github.com/Gozargah/Marzban/issues/861
Now Mux Template works as a Master controller
If Mux is Enabled for Sing-Box and Enabled for a Host, that Host will have Mux enabled in it's sing-box client config
But if Mux is Disable in Mux Template, Mux will always be disabled in all Sing-Box client configs no matter what is Host's setting
As Sing-Box have no Mux.Cool so it's better to be disabled by default, but you can change if you think i'm wrong