### PR TITLE
Fix v2ray-custom userLevel

### DIFF
--- a/app/subscription/v2ray.py
+++ b/app/subscription/v2ray.py
@@ -423,6 +423,7 @@ class V2rayJsonConfig(str):
         users["alterId"] = 0
         users["email"] = "https://gozargah.github.io/marzban/"
         users["security"] = "auto"
+        users["level"] = 8
         vnext["users"] = [users]
 
         return [vnext]
@@ -442,6 +443,7 @@ class V2rayJsonConfig(str):
         users["encryption"] = "none"
         if flow:
             users["flow"] = flow
+        users["level"] = 8
         vnext["users"] = [users]
 
         return [vnext]
@@ -458,7 +460,7 @@ class V2rayJsonConfig(str):
         servers["email"] = "https://gozargah.github.io/marzban/"
         servers["method"] = method
         servers["ota"] = False
-        servers["level"] = 1
+        servers["level"] = 8
 
         settings["servers"] = [servers]
 
@@ -476,7 +478,7 @@ class V2rayJsonConfig(str):
         servers["email"] = "https://gozargah.github.io/marzban/"
         servers["method"] = method
         servers["uot"] = False
-        servers["level"] = 1
+        servers["level"] = 8
 
         settings["servers"] = [servers]
 


### PR DESCRIPTION
For policy section of v2rayNG we need to use a userLevel
i just exported an config from v2rayNG, it's default userlevel was 8 so i used 8 for default userLevel
![image](https://github.com/Gozargah/Marzban/assets/161948085/b6648614-70ce-4bf7-879f-c8e8e633dab2)
