### PR TITLE
regex fix

### DIFF
--- a/app/models/proxy.py
+++ b/app/models/proxy.py
@@ -16,7 +16,7 @@ from xray_api.types.account import (
     XTLSFlows
 )
 
-FRAGMENT_PATTERN = re.compile(r'^(\d{1,3}-\d{1,3}),(\d{1,3}-\d{1,3}),(tlshello|\d|\d\-\d)$')
+FRAGMENT_PATTERN = re.compile(r'^((\d{1,3}-\d{1,3})|(\d{1,3})),((\d{1,3}-\d{1,3})|(\d{1,3})),(tlshello|\d|\d\-\d)$')
 
 
 class ProxyTypes(str, Enum):


### PR DESCRIPTION
In the freedom outbound, for fragment, you can set a single digit or a range
currently Marzban forces user to use a range, but i have changed it to accept single digit too