### PR TITLE
Resolved multiple issues in singbox.py

### DIFF
--- a/app/subscription/singbox.py
+++ b/app/subscription/singbox.py
@@ -148,7 +148,8 @@ class SingBoxConfiguration(str):
             "server": address,
             "server_port": port,
         }
-        if net in ('tcp', 'kcp') and headers != 'http' and tls:
+
+        if net in ('tcp', 'kcp') and headers != 'http' and tls != 'none':
             if flow:
                 config["flow"] = flow
 
@@ -157,6 +158,7 @@ class SingBoxConfiguration(str):
             alpn = 'h2'
         elif net in ['tcp'] and headers == 'http':
             net = 'http'
+
 
         if net in ['http', 'ws', 'quic', 'grpc', 'httpupgrade']:
             max_early_data = None
@@ -176,19 +178,20 @@ class SingBoxConfiguration(str):
                 early_data_header_name=early_data_header_name
             )
         else:
-            config["network"]: net
+            config["network"] = net
 
         if tls in ('tls', 'reality'):
             config['tls'] = self.tls_config(sni=sni, fp=fp, tls=tls,
                                             pbk=pbk, sid=sid, alpn=alpn,
                                             ais=ais)
-
-        mux_json = json.loads(self.mux_template)
-        mux_config = mux_json["sing-box"]
-
-        config['multiplex'] = mux_config
-        if config['multiplex']["enabled"]:
-            config['multiplex']["enabled"] = mux_enable
+        
+        # Singbox mux is not compatible with xray mux
+        # Since marzban doesnt support singbox core at server side at the moment - sinbox-mux should not be enabled at all
+        # if mux_enable:
+        #     mux_json = json.loads(self.mux_template)
+        #     mux_config = mux_json["sing-box"]
+        #     config['multiplex'] = mux_config
+        #     config['multiplex']["enabled"] = mux_enable
 
         return config
 


### PR DESCRIPTION

Firstly this PR addresses an issue with the MUX algorithm within the SingBox subscription configuration. Previously, the algorithm did not function correctly and would always append `"enabled": false` to the multiplex configuration regardless of host input, as shown below:

```json
"multiplex": {
  "enabled": false,
  "protocol": "h2mux",
  "max_streams": 8
}
```

This behavior prevented the enabling of the MUX feature. The updated algorithm now correctly handles the MUX state. When MUX is enabled, the following configuration is added:

```json
"multiplex": {
  "enabled": true,
  "protocol": "h2mux",
  "max_streams": 8
}
```

Conversely, when MUX is disabled, no multiplex configuration is appended to the custom JSON.

**Additionally, the entire MUX generation section has been commented out because the Marzban server-side does not yet support SingBox, and the SingBox MUX is not compatible with Xray MUX.**

Another fix introduced in this PR is the handling of the `flow` setting. In the past, every VLESS configuration included the `flow` in the custom JSON, which caused issues for VLESS TCP noHEADER noTLS inbounds. Now, the `flow` is only activated if the `tls` value is not `"none"`.

Lastly, a syntax error on line 181 has been corrected by replacing a colon (`:`) with an equals sign (`=`), as it should be.

These changes ensure that the SingBox subscription configuration operates as intended and is compatible with the current server-side capabilities.