### PR TITLE
fix: :bug: Disabled Clash Meta Flow for non-TLS configs

### DIFF
--- a/app/utils/share.py
+++ b/app/utils/share.py
@@ -440,7 +440,7 @@ class ClashMetaConfiguration(ClashConfiguration):
         if inbound['protocol'] == 'vless':
             node['uuid'] = settings['id']
 
-            if inbound['network'] in ('tcp', 'kcp') and inbound['header_type'] != 'http':
+            if inbound['network'] in ('tcp', 'kcp') and inbound['header_type'] != 'http' and inbound['tls']:
                 node['flow'] = settings.get('flow', '')
 
             self.data['proxies'].append(node)


### PR DESCRIPTION
non-TLS configs doesn't support flow and the config won't work if flow has been set so , i disabled it for non-TLS configs in clash-meta file (it was disabled for other clients)