### PR TITLE
bug: 🐛Disabled Clash Meta Flow for non-TLS TCP & KCP configs

### DIFF
--- a/app/subscription/clash.py
+++ b/app/subscription/clash.py
@@ -244,7 +244,7 @@ class ClashMetaConfiguration(ClashConfiguration):
         if inbound['protocol'] == 'vless':
             node['uuid'] = settings['id']
 
-            if inbound['network'] in ('tcp', 'kcp') and inbound['header_type'] != 'http':
+            if inbound['network'] in ('tcp', 'kcp') and inbound['header_type'] != 'http' and inbound['tls'] != 'none':
                 node['flow'] = settings.get('flow', '')
 
             self.data['proxies'].append(node)


### PR DESCRIPTION
non-TLS configs doesn't support flow and the config won't work if flow has been set so , i disabled it for non-TLS configs in clash-meta file (it was disabled for other clients)