### PR TITLE
Remove enabling 'multiplex' in sing-box config when mux is enabled

### DIFF
--- a/app/subscription/singbox.py
+++ b/app/subscription/singbox.py
@@ -187,7 +187,6 @@ class SingBoxConfiguration(str):
             mux_json = json.loads(self.mux_template)
             mux_config = mux_json["sing-box"]
             config['multiplex'] = mux_config
-            config['multiplex']["enabled"] = mux_enable
 
         return config
 


### PR DESCRIPTION
Previously, enabling mux for v2rayng would also enable 'multiplex' in the sing-box configuration, causing the config to not work as intended. This change ensures that 'multiplex' is not enabled in sing-box config even if mux is enabled for v2rayng. Enabling and disabling mux can now be managed directly within the sing-box mux template.