### PR TITLE
v2ray-json conf only for 1.8.18+ versions of v2rayNG

### DIFF
--- a/app/views/subscription.py
+++ b/app/views/subscription.py
@@ -107,7 +107,7 @@ def user_subscription(token: str,
 
     elif re.match('^v2rayNG/(\d+\.\d+\.\d+)', user_agent):
         version_str = re.match('^v2rayNG/(\d+\.\d+\.\d+)', user_agent).group(1)
-        if LooseVersion(version_str) >= LooseVersion("1.8.16") and \
+        if LooseVersion(version_str) >= LooseVersion("1.8.18") and \
                 (USE_CUSTOM_JSON_DEFAULT or USE_CUSTOM_JSON_FOR_V2RAYNG):
             conf = generate_subscription(user=user, config_format="v2ray-json", as_base64=False)
             return Response(content=conf, media_type="application/json", headers=response_headers)


### PR DESCRIPTION
1.8.16 and 1.8.17 versions of v2rayNG is not able to parse json configs correctly, they can't parse early data parameter and with some json templates they can't even connect to configs
so it's better to just send them old type v2ray configs