### PR TITLE
add External config to import into v2ray format sub

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,9 @@ UVICORN_PORT = 8000
 # SUB_UPDATE_INTERVAL = "12"
 # RANDOMIZE_SUBSCRIPTION_CONFIGS = True
 
+## External config to import into v2ray format subscription
+# EXTERNAL_CONFIG = "config://..."
+
 # SQLALCHEMY_DATABASE_URL = "sqlite:///db.sqlite3"
 
 ## Custom text for STATUS_TEXT variable

--- a/app/subscription/share.py
+++ b/app/subscription/share.py
@@ -19,7 +19,8 @@ if TYPE_CHECKING:
 
 from config import (ACTIVE_STATUS_TEXT, DISABLED_STATUS_TEXT,
                     EXPIRED_STATUS_TEXT, LIMITED_STATUS_TEXT,
-                    ONHOLD_STATUS_TEXT, RANDOMIZE_SUBSCRIPTION_CONFIGS)
+                    ONHOLD_STATUS_TEXT, RANDOMIZE_SUBSCRIPTION_CONFIGS,
+                    EXTERNAL_CONFIG)
 
 SERVER_IP = get_public_ip()
 SERVER_IPV6 = get_public_ipv6()
@@ -144,6 +145,7 @@ def generate_subscription(
 
     if config_format == "v2ray":
         config = "\n".join(generate_v2ray_links(**kwargs))
+        config += "\n" + EXTERNAL_CONFIG 
     elif config_format == "clash-meta":
         config = generate_clash_subscription(**kwargs, is_meta=True)
     elif config_format == "clash":

--- a/app/subscription/share.py
+++ b/app/subscription/share.py
@@ -15,7 +15,7 @@ from app.utils.system import get_public_ip, get_public_ipv6, readable_size
 from . import *
 
 if TYPE_CHECKING:
-    from app.models.user import UserResponse
+    from app.models.user import UserResponse, UserStatus
 
 from config import (ACTIVE_STATUS_TEXT, DISABLED_STATUS_TEXT,
                     EXPIRED_STATUS_TEXT, LIMITED_STATUS_TEXT,
@@ -145,7 +145,8 @@ def generate_subscription(
 
     if config_format == "v2ray":
         config = "\n".join(generate_v2ray_links(**kwargs))
-        config += "\n" + EXTERNAL_CONFIG 
+        if user.status == UserStatus.active:
+            config += "\n" + EXTERNAL_CONFIG 
     elif config_format == "clash-meta":
         config = generate_clash_subscription(**kwargs, is_meta=True)
     elif config_format == "clash":

--- a/config.py
+++ b/config.py
@@ -53,6 +53,7 @@ V2RAY_SUBSCRIPTION_TEMPLATE = config("V2RAY_SUBSCRIPTION_TEMPLATE", default="v2r
 USER_AGENT_TEMPLATE = config("USER_AGENT_TEMPLATE", default="user_agent/default.json")
 GRPC_USER_AGENT_TEMPLATE = config("GRPC_USER_AGENT_TEMPLATE", default="user_agent/grpc.json")
 
+EXTERNAL_CONFIG = config("EXTERNAL_CONFIG", default=False, cast=str)
 
 USE_CUSTOM_JSON_DEFAULT = config("USE_CUSTOM_JSON_DEFAULT", default=False, cast=bool)
 USE_CUSTOM_JSON_FOR_V2RAYN = config("USE_CUSTOM_JSON_FOR_V2RAYN", default=False, cast=bool)


### PR DESCRIPTION
With this feature, you can automatically apply temporary V2Ray configurations to your `active users' subscriptions` (in `V2Ray format`) during connection outages, allowing them to stay connected until maintenance is completed.