### PR TITLE
Enhance SNI and Host Selection Logic Based on List Lengths

### DIFF
--- a/app/subscription/share.py
+++ b/app/subscription/share.py
@@ -303,16 +303,20 @@ def process_inbounds_and_tags(
             host_inbound = inbound.copy()
             for host in xray.hosts.get(tag, []):
                 sni = ""
-                sni_list = host["sni"] or inbound["sni"]
-                if sni_list:
-                    salt = secrets.token_hex(8)
-                    sni = random.choice(sni_list).replace("*", salt)
-
                 req_host = ""
+                sni_list = host["sni"] or inbound["sni"]
                 req_host_list = host["host"] or inbound["host"]
-                if req_host_list:
-                    salt = secrets.token_hex(8)
-                    req_host = random.choice(req_host_list).replace("*", salt)
+
+                if sni_list and req_host_list and len(sni_list) == len(req_host_list):
+                    index = random.randint(0, len(sni_list) - 1)
+                    sni = sni_list[index].replace("*", secrets.token_hex(8))
+                    req_host = req_host_list[index].replace("*", secrets.token_hex(8))
+                else:
+                    if sni_list:
+                        sni = random.choice(sni_list).replace("*", secrets.token_hex(8))
+                    if req_host_list:
+                        req_host = random.choice(req_host_list).replace("*", secrets.token_hex(8))
+
                 if host['address']:
                     salt = secrets.token_hex(8)
                     address = host['address'].replace('*', salt)


### PR DESCRIPTION
If the lengths of sni_list and req_host_list are the same, it selects a random index and uses the corresponding elements from both lists. If the lengths are different, it falls back to the original behavior of selecting random elements independently.