### PR TITLE
feat(subtitle): add ability to change subtitle to user's username

### DIFF
--- a/app/models/user.py
+++ b/app/models/user.py
@@ -285,8 +285,9 @@ class UserResponse(User):
         if not v:
             salt = secrets.token_hex(8)
             url_prefix = (XRAY_SUBSCRIPTION_URL_PREFIX).replace('*', salt)
-            token = create_subscription_token(values["username"])
-            return f"{url_prefix}/{XRAY_SUBSCRIPTION_PATH}/{token}"
+            username = values["username"]
+            token = create_subscription_token(username)
+            return f"{url_prefix}/{XRAY_SUBSCRIPTION_PATH}/{token}#{username}"
         return v
 
     @validator("proxies", pre=True, always=True)

--- a/app/views/subscription.py
+++ b/app/views/subscription.py
@@ -68,7 +68,7 @@ def user_subscription(token: str,
         "content-disposition": f'attachment; filename="{user.username}"',
         "profile-web-page-url": str(request.url),
         "support-url": SUB_SUPPORT_URL,
-        "profile-title": encode_title(SUB_PROFILE_TITLE),
+        "profile-title": encode_title(user.username if SUB_PROFILE_TITLE == 'username' else SUB_PROFILE_TITLE),
         "profile-update-interval": SUB_UPDATE_INTERVAL,
         "subscription-userinfo": "; ".join(
             f"{key}={val}"


### PR DESCRIPTION
Some users have requested that in software like `Hiddify Next`, instead of the `Subscription title`, the username of the users should be displayed. I have added this feature as an `option`. If you write `username for the Subscription title`, each user's title will become their username; otherwise, whatever else you write will be displayed as the title.

- [x] feat: add ability to change subtitle to user's username