### PR TITLE
fix(config): Corrupting the hosts' data

### DIFF
--- a/app/subscription/share.py
+++ b/app/subscription/share.py
@@ -265,8 +265,9 @@ def process_inbounds_and_tags(
                 continue
 
             format_variables.update({"TRANSPORT": inbound["network"]})
-            host_inbound = inbound.copy()
+
             for host in xray.hosts.get(tag, []):
+                host_inbound = inbound.copy()
                 
                 sni = ""
                 sni_list = host["sni"] or inbound["sni"]


### PR DESCRIPTION
I tested each step individually and confirmed that the `shuffle` operation does not cause any issues. The problem was with the `host_inbound` configuration. This issue has been resolved with the recent pull request. The problem is now fixed, and everything has been tested and is working correctly.

I apologize for the bug that occurred. In future pull requests, I will ensure to conduct more thorough testing and consider all potential edge cases to avoid similar issues.