### PR TITLE
Setup-CORS-policies

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 UVICORN_HOST = "0.0.0.0"
 UVICORN_PORT = 8000
-
+# ALLWED_ORIGINS=http://localhost,http://localhost:8000,http://example.com
 
 ## We highly recommend add admin using `marzban cli` tool and do not use
 ## the following variables which is somehow hard codded infrmation.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -9,7 +9,7 @@ from fastapi.responses import JSONResponse
 from fastapi.routing import APIRoute
 from fastapi_responses import custom_openapi
 
-from config import DOCS, XRAY_SUBSCRIPTION_PATH
+from config import ALLWED_ORIGINS, DOCS, XRAY_SUBSCRIPTION_PATH
 
 __version__ = "0.6.0"
 
@@ -26,7 +26,7 @@ scheduler = BackgroundScheduler({'apscheduler.job_defaults.max_instances': 20}, 
 logger = logging.getLogger('uvicorn.error')
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=ALLWED_ORIGINS,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/config.py
+++ b/config.py
@@ -17,6 +17,8 @@ UVICORN_SSL_KEYFILE = config("UVICORN_SSL_KEYFILE", default=None)
 DEBUG = config("DEBUG", default=False, cast=bool)
 DOCS = config("DOCS", default=False, cast=bool)
 
+ALLWED_ORIGINS = config("ALLWED_ORIGINS", default="*").split(",")
+
 VITE_BASE_API = f"http://127.0.0.1:{UVICORN_PORT}/api/" \
     if DEBUG and config("VITE_BASE_API", default="/api/") == "/api/" \
     else config("VITE_BASE_API", default="/api/")


### PR DESCRIPTION
- add allowed origins to CORS-middleware. By default, all origins are allowed but you could restrict by setting the `ALLWED_ORIGINS` env variable