### PR TITLE
Hide obfuscated quic for clash-meta and sing-box

### DIFF
--- a/app/subscription/clash.py
+++ b/app/subscription/clash.py
@@ -333,7 +333,7 @@ class ClashMetaConfiguration(ClashConfiguration):
 
     def add(self, remark: str, address: str, inbound: dict, settings: dict):
         # not supported by clash-meta
-        if inbound['network'] in ("kcp", "splithttp"):
+        if inbound['network'] in ("kcp", "splithttp") or (inbound['network'] == "quic" and inbound["header_type"] != "none"):
             return
 
         node = self.make_node(

--- a/app/subscription/singbox.py
+++ b/app/subscription/singbox.py
@@ -282,7 +282,7 @@ class SingBoxConfiguration(str):
         path = inbound["path"]
 
         # not supported by sing-box
-        if net in ("kcp", "splithttp"):
+        if net in ("kcp", "splithttp") or (net == "quic" and inbound["header_type"] != "none"):
             return
 
         if net in ("grpc", "gun"):


### PR DESCRIPTION
obfuscated quic not supported by any core except Xray, and if it exist in sing-box subscription it will causes errors in sing-box and prevent subscription updates
this PR fixed it
