### PR TITLE
Feat(api): Adding the ability to calculate the consumption of admin users

### DIFF
--- a/app/models/user.py
+++ b/app/models/user.py
@@ -335,3 +335,6 @@ class UserUsageResponse(BaseModel):
 class UserUsagesResponse(BaseModel):
     username: str
     usages: List[UserUsageResponse]
+
+class UsersUsagesResponse(BaseModel):
+    usages: List[UserUsageResponse]


### PR DESCRIPTION
I added a `new api` to receive the consumption of users of one or more specified admins.

- [x] Feat(api): Added API endpoint to retrieve users consumption data.
- [x] Feat(crud): Implemented function to get users usage information.
- [x] Feat(models): added UsersUsagesResponse to user models.