### PR TITLE
Read SplitHTTP Settings from Template if there is any

### DIFF
--- a/app/subscription/v2ray.py
+++ b/app/subscription/v2ray.py
@@ -205,8 +205,14 @@ class V2rayShareLink(str):
 
         elif net == "splithttp":
             # before 1.8.23
-            payload["maxUploadSize"] = sc_max_each_post_bytes
-            payload["maxConcurrentUploads"] = sc_max_concurrent_posts
+            if isinstance(sc_max_each_post_bytes, int):
+                payload["maxUploadSize"] = sc_max_each_post_bytes
+            else:
+                payload["maxUploadSize"] = sc_max_each_post_bytes.split("-")[1]
+            if isinstance(sc_max_concurrent_posts, int):
+                payload["maxConcurrentUploads"] = sc_max_concurrent_posts
+            else:
+                payload["maxConcurrentUploads"] = sc_max_concurrent_posts.split("-")[1]
             # 1.8.23 and later
             payload["scMaxEachPostBytes"] = sc_max_each_post_bytes
             payload["scMaxConcurrentPosts"] = sc_max_concurrent_posts
@@ -269,8 +275,14 @@ class V2rayShareLink(str):
             payload["path"] = path
             payload["host"] = host
             # before 1.8.23
-            payload["maxUploadSize"] = sc_max_each_post_bytes
-            payload["maxConcurrentUploads"] = sc_max_concurrent_posts
+            if isinstance(sc_max_each_post_bytes, int):
+                payload["maxUploadSize"] = sc_max_each_post_bytes
+            else:
+                payload["maxUploadSize"] = sc_max_each_post_bytes.split("-")[1]
+            if isinstance(sc_max_concurrent_posts, int):
+                payload["maxConcurrentUploads"] = sc_max_concurrent_posts
+            else:
+                payload["maxConcurrentUploads"] = sc_max_concurrent_posts.split("-")[1]
             # 1.8.23 and later
             payload["scMaxEachPostBytes"] = sc_max_each_post_bytes
             payload["scMaxConcurrentPosts"] = sc_max_concurrent_posts
@@ -355,8 +367,14 @@ class V2rayShareLink(str):
             payload["path"] = path
             payload["host"] = host
             # before 1.8.23
-            payload["maxUploadSize"] = sc_max_each_post_bytes
-            payload["maxConcurrentUploads"] = sc_max_concurrent_posts
+            if isinstance(sc_max_each_post_bytes, int):
+                payload["maxUploadSize"] = sc_max_each_post_bytes
+            else:
+                payload["maxUploadSize"] = sc_max_each_post_bytes.split("-")[1]
+            if isinstance(sc_max_concurrent_posts, int):
+                payload["maxConcurrentUploads"] = sc_max_concurrent_posts
+            else:
+                payload["maxConcurrentUploads"] = sc_max_concurrent_posts.split("-")[1]
             # 1.8.23 and later
             payload["scMaxEachPostBytes"] = sc_max_each_post_bytes
             payload["scMaxConcurrentPosts"] = sc_max_concurrent_posts
@@ -532,6 +550,10 @@ class V2rayJsonConfig(str):
         # before 1.8.23
         config.setdefault('maxUploadSize', sc_max_each_post_bytes)
         config.setdefault('maxConcurrentUploads', sc_max_concurrent_posts)
+        if isinstance(config["maxUploadSize"], str):
+            payload["maxUploadSize"] = config["maxUploadSize"].split("-")[1]
+        if isinstance(config["maxConcurrentUploads"], str):
+            payload["maxConcurrentUploads"] = config["maxConcurrentUploads"].split("-")[1]
         # 1.8.23 and later
         config.setdefault('scMaxEachPostBytes', sc_max_each_post_bytes)
         config.setdefault('scMaxConcurrentPosts', sc_max_concurrent_posts)


### PR DESCRIPTION
If user add any setting for SplitHTTP in the template, Marzban will use it instead of core or default settings (but by default there is no SplitHTTP settings in the Template file, so will not make any problem for anyone)
Fixes https://github.com/Gozargah/Marzban/issues/1277 and makes users able to fix https://github.com/Gozargah/Marzban/issues/1279 by setting custom settings in the Template file