### PR TITLE
Add npm in dockerfile to using debug=true in docker environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV PYTHONUNBUFFERED 1
 WORKDIR /code
 
 RUN apt-get update \
-    && apt-get install -y curl unzip gcc python3-dev \
+    && apt-get install -y curl unzip gcc python3-dev npm \
     && rm -rf /var/lib/apt/lists/*
 
 RUN bash -c "$(curl -L https://github.com/Gozargah/Marzban-scripts/raw/master/install_latest_xray.sh)"


### PR DESCRIPTION
## Summary

This pull request introduces a modification to the Marzban project to enhance debugging capabilities in the Docker environment by ensuring that an optional npm package is installed only when the DEBUG=true variable is enabled.

## Problem Statement

Currently, the Marzban project does not account for the installation of npm packages required for debugging within the Docker environment. When debugging (DEBUG=true) is enabled, these packages are necessary but are not automatically included in the Docker build process.

This pull request fixes #634