### PR TITLE
Add singbox-only protocols for selector and urltest

### DIFF
--- a/app/subscription/singbox.py
+++ b/app/subscription/singbox.py
@@ -49,10 +49,10 @@ class SingBoxConfiguration(str):
         self.config["outbounds"].append(outbound_data)
 
     def render(self, reverse=False):
-        urltest_types = ["vmess", "vless", "trojan", "shadowsocks"]
+        urltest_types = ["vmess", "vless", "trojan", "shadowsocks", "hysteria2", "tuic"]
         urltest_tags = [outbound["tag"]
                         for outbound in self.config["outbounds"] if outbound["type"] in urltest_types]
-        selector_types = ["vmess", "vless", "trojan", "shadowsocks", "urltest"]
+        selector_types = ["vmess", "vless", "trojan", "shadowsocks", "hysteria2", "tuic", "urltest"]
         selector_tags = [outbound["tag"]
                          for outbound in self.config["outbounds"] if outbound["type"] in selector_types]
 

--- a/app/subscription/singbox.py
+++ b/app/subscription/singbox.py
@@ -49,10 +49,10 @@ class SingBoxConfiguration(str):
         self.config["outbounds"].append(outbound_data)
 
     def render(self, reverse=False):
-        urltest_types = ["vmess", "vless", "trojan", "shadowsocks", "hysteria2", "tuic"]
+        urltest_types = ["vmess", "vless", "trojan", "shadowsocks", "hysteria2", "tuic", "http", "ssh"]
         urltest_tags = [outbound["tag"]
                         for outbound in self.config["outbounds"] if outbound["type"] in urltest_types]
-        selector_types = ["vmess", "vless", "trojan", "shadowsocks", "hysteria2", "tuic", "urltest"]
+        selector_types = ["vmess", "vless", "trojan", "shadowsocks", "hysteria2", "tuic", "http", "ssh", "urltest"]
         selector_tags = [outbound["tag"]
                          for outbound in self.config["outbounds"] if outbound["type"] in selector_types]
 


### PR DESCRIPTION
Motivation:
I use a custom singbox subscription template (using `SINGBOX_SUBSCRIPTION_TEMPLATE`). There, I include extra custom outbounds (vless, vmess, hysteria2, tuic, naive https...) with unmetered traffic.

The issue is that the ones with singbox-only protocols, such as hysteria2 and tuic, are not included in the selector and url-test. (even though they are correctly put in the generated json and singbox supports them)

This code is meant just for singbox clients, so there won't be any problems with other clients. It's also good for the future if xray adds these protocols.

Ideally, we can also add other protocols from here as well:
https://sing-box.sagernet.org/configuration/outbound/