### PR TITLE
add real upload/download splitting to xhttp

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -10,7 +10,7 @@ from fastapi.routing import APIRoute
 
 from config import ALLOWED_ORIGINS, DOCS, XRAY_SUBSCRIPTION_PATH
 
-__version__ = "0.8.2"
+__version__ = "0.8.3"
 
 app = FastAPI(
     title="MarzbanAPI",

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -10,7 +10,7 @@ from fastapi.routing import APIRoute
 
 from config import ALLOWED_ORIGINS, DOCS, XRAY_SUBSCRIPTION_PATH
 
-__version__ = "0.8.3"
+__version__ = "0.8.4"
 
 app = FastAPI(
     title="MarzbanAPI",

--- a/app/subscription/v2ray.py
+++ b/app/subscription/v2ray.py
@@ -81,6 +81,7 @@ class V2rayShareLink(str):
                 heartbeatPeriod=inbound.get("heartbeatPeriod", 0),
                 keepAlivePeriod=inbound.get("keepAlivePeriod", 0),
                 xmux=inbound.get("xmux", {}),
+                downloadSettings=inbound.get("downloadSettings",{})
             )
 
         elif inbound["protocol"] == "vless":
@@ -113,6 +114,7 @@ class V2rayShareLink(str):
                 heartbeatPeriod=inbound.get("heartbeatPeriod", 0),
                 keepAlivePeriod=inbound.get("keepAlivePeriod", 0),
                 xmux=inbound.get("xmux", {}),
+                downloadSettings=inbound.get("downloadSettings",{})
             )
 
         elif inbound["protocol"] == "trojan":
@@ -145,6 +147,7 @@ class V2rayShareLink(str):
                 heartbeatPeriod=inbound.get("heartbeatPeriod", 0),
                 keepAlivePeriod=inbound.get("keepAlivePeriod", 0),
                 xmux=inbound.get("xmux", {}),
+                downloadSettings=inbound.get("downloadSettings",{})
             )
 
         elif inbound["protocol"] == "shadowsocks":
@@ -190,6 +193,7 @@ class V2rayShareLink(str):
             heartbeatPeriod: int = 0,
             keepAlivePeriod: int = 0,
             xmux: dict = {},
+            downloadSettings: dict = {},
     ):
         payload = {
             "add": address,
@@ -243,6 +247,8 @@ class V2rayShareLink(str):
             }
             if xmux:
                 extra["xmux"] = xmux
+            if downloadSettings:
+                extra["downloadSettings"] = downloadSettings
             payload["type"] = mode
             if keepAlivePeriod > 0:
                 extra["keepAlivePeriod"] = keepAlivePeriod
@@ -289,6 +295,7 @@ class V2rayShareLink(str):
               heartbeatPeriod: int = 0,
               keepAlivePeriod: int = 0,
               xmux: dict = {},
+              downloadSettings: dict = {},
               ):
 
         payload = {
@@ -326,6 +333,8 @@ class V2rayShareLink(str):
                 extra["keepAlivePeriod"] = keepAlivePeriod
             if xmux:
                 extra["xmux"] = xmux
+            if downloadSettings:
+                extra["downloadSettings"] = downloadSettings
             payload["extra"] = json.dumps(extra)
 
         elif net == 'kcp':
@@ -397,6 +406,7 @@ class V2rayShareLink(str):
                heartbeatPeriod: int = 0,
                keepAlivePeriod: int = 0,
                xmux: dict = {},
+               downloadSettings: dict = {},
                ):
 
         payload = {
@@ -430,6 +440,8 @@ class V2rayShareLink(str):
                 extra["keepAlivePeriod"] = keepAlivePeriod
             if xmux:
                 extra["xmux"] = xmux
+            if downloadSettings:
+                extra["downloadSettings"] = downloadSettings
             payload["extra"] = json.dumps(extra)
 
         elif net == 'quic':
@@ -599,6 +611,7 @@ class V2rayJsonConfig(str):
                          sc_min_posts_interval_ms: int = 30,
                          x_padding_bytes: str = "100-1000",
                          xmux: dict = {},
+                         downloadSettings: dict = {},
                          mode: str = "auto",
                          noGRPCHeader: bool = False,
                          keepAlivePeriod: int = 0,
@@ -620,6 +633,8 @@ class V2rayJsonConfig(str):
         config["noGRPCHeader"] = noGRPCHeader
         if xmux:
             config["xmux"] = xmux
+        if downloadSettings:
+            config["downloadSettings"] = downloadSettings
         if keepAlivePeriod > 0:
             config["keepAlivePeriod"] = keepAlivePeriod
         # core will ignore unknown variables
@@ -922,6 +937,7 @@ class V2rayJsonConfig(str):
                             sc_min_posts_interval_ms: int = 30,
                             x_padding_bytes: str = "100-1000",
                             xmux: dict = {},
+                            downloadSettings: dict = {},
                             mode: str = "auto",
                             noGRPCHeader: bool = False,
                             heartbeatPeriod: int = 0,
@@ -956,6 +972,7 @@ class V2rayJsonConfig(str):
                                                     sc_min_posts_interval_ms=sc_min_posts_interval_ms,
                                                     x_padding_bytes=x_padding_bytes,
                                                     xmux=xmux,
+                                                    downloadSettings=downloadSettings,
                                                     mode=mode,
                                                     noGRPCHeader=noGRPCHeader,
                                                     keepAlivePeriod=keepAlivePeriod,
@@ -1066,6 +1083,7 @@ class V2rayJsonConfig(str):
             sc_min_posts_interval_ms=inbound.get('scMinPostsIntervalMs', 30),
             x_padding_bytes=inbound.get("xPaddingBytes", "100-1000"),
             xmux=inbound.get("xmux", {}),
+            downloadSettings=inbound.get("downloadSettings",{}),
             mode=inbound.get("mode", "auto"),
             noGRPCHeader=inbound.get("noGRPCHeader", False),
             heartbeatPeriod=inbound.get("heartbeatPeriod", 0),

--- a/app/subscription/v2ray.py
+++ b/app/subscription/v2ray.py
@@ -251,7 +251,7 @@ class V2rayShareLink(str):
                 extra["downloadSettings"] = downloadSettings
             payload["type"] = mode
 
-            payload["extra"] = extra
+            payload["extra"] = (json.dumps(extra)).replace(" ","")
 
         elif net == "ws":
             if heartbeatPeriod:
@@ -332,7 +332,7 @@ class V2rayShareLink(str):
                 extra["xmux"] = xmux
             if downloadSettings:
                 extra["downloadSettings"] = downloadSettings
-            payload["extra"] = extra
+            payload["extra"] = (json.dumps(extra)).replace(" ","")
 
         elif net == 'kcp':
             payload['seed'] = path
@@ -437,7 +437,7 @@ class V2rayShareLink(str):
                 extra["xmux"] = xmux
             if downloadSettings:
                 extra["downloadSettings"] = downloadSettings
-            payload["extra"] = json.dumps(extra)
+            payload["extra"] = (json.dumps(extra)).replace(" ","")
 
         elif net == 'quic':
             payload['key'] = path

--- a/app/subscription/v2ray.py
+++ b/app/subscription/v2ray.py
@@ -250,7 +250,7 @@ class V2rayShareLink(str):
             if downloadSettings:
                 extra["downloadSettings"] = downloadSettings
             payload["type"] = mode
-            
+
             payload["extra"] = extra
 
         elif net == "ws":
@@ -328,8 +328,6 @@ class V2rayShareLink(str):
                 "xPaddingBytes": x_padding_bytes,
                 "noGRPCHeader": noGRPCHeader,
             }
-            if keepAlivePeriod > 0:
-                extra["keepAlivePeriod"] = keepAlivePeriod
             if xmux:
                 extra["xmux"] = xmux
             if downloadSettings:
@@ -435,8 +433,6 @@ class V2rayShareLink(str):
                 "xPaddingBytes": x_padding_bytes,
                 "noGRPCHeader": noGRPCHeader,
             }
-            if keepAlivePeriod > 0:
-                extra["keepAlivePeriod"] = keepAlivePeriod
             if xmux:
                 extra["xmux"] = xmux
             if downloadSettings:

--- a/app/subscription/v2ray.py
+++ b/app/subscription/v2ray.py
@@ -332,7 +332,7 @@ class V2rayShareLink(str):
                 extra["xmux"] = xmux
             if downloadSettings:
                 extra["downloadSettings"] = downloadSettings
-            payload["extra"] = json.dumps(extra)
+            payload["extra"] = extra
 
         elif net == 'kcp':
             payload['seed'] = path

--- a/app/subscription/v2ray.py
+++ b/app/subscription/v2ray.py
@@ -248,6 +248,7 @@ class V2rayShareLink(str):
             if xmux:
                 extra["xmux"] = xmux
             if downloadSettings:
+                print("DOWNLOAD SETTINGS HAS BEEN SET")
                 extra["downloadSettings"] = downloadSettings
             payload["type"] = mode
             if keepAlivePeriod > 0:

--- a/app/subscription/v2ray.py
+++ b/app/subscription/v2ray.py
@@ -248,11 +248,9 @@ class V2rayShareLink(str):
             if xmux:
                 extra["xmux"] = xmux
             if downloadSettings:
-                print("DOWNLOAD SETTINGS HAS BEEN SET")
                 extra["downloadSettings"] = downloadSettings
             payload["type"] = mode
-            if keepAlivePeriod > 0:
-                extra["keepAlivePeriod"] = keepAlivePeriod
+            
             payload["extra"] = extra
 
         elif net == "ws":

--- a/app/xray/config.py
+++ b/app/xray/config.py
@@ -308,6 +308,7 @@ class XRayConfig(dict):
                     settings['scMinPostsIntervalMs'] = net_settings.get('scMinPostsIntervalMs', 30)
                     settings['xPaddingBytes'] = net_settings.get('xPaddingBytes', "100-1000")
                     settings['xmux'] = net_settings.get('xmux', {})
+                    settings['downloadSettings'] = net_settings.get('downloadSettings',{})
                     settings["mode"] = net_settings.get("mode", "auto")
                     settings["noGRPCHeader"] = net_settings.get("noGRPCHeader", False)
                     settings["keepAlivePeriod"] = net_settings.get("keepAlivePeriod", 0)

--- a/app/xray/config.py
+++ b/app/xray/config.py
@@ -303,15 +303,16 @@ class XRayConfig(dict):
                     settings['path'] = net_settings.get('path', '')
                     host = net_settings.get('host', '')
                     settings['host'] = [host]
-                    settings['scMaxEachPostBytes'] = net_settings.get('scMaxEachPostBytes', 1000000)
-                    settings['scMaxConcurrentPosts'] = net_settings.get('scMaxConcurrentPosts', 100)
-                    settings['scMinPostsIntervalMs'] = net_settings.get('scMinPostsIntervalMs', 30)
-                    settings['xPaddingBytes'] = net_settings.get('xPaddingBytes', "100-1000")
-                    settings['xmux'] = net_settings.get('xmux', {})
-                    settings['downloadSettings'] = net_settings.get('downloadSettings',{})
+                    extra = net_settings.get('extra',{})
+                    settings['scMaxEachPostBytes'] = extra.get('scMaxEachPostBytes', 1000000)
+                    settings['scMaxConcurrentPosts'] = extra.get('scMaxConcurrentPosts', 100)
+                    settings['scMinPostsIntervalMs'] = extra.get('scMinPostsIntervalMs', 30)
+                    settings['xPaddingBytes'] = extra.get('xPaddingBytes', "100-1000")
+                    settings["noGRPCHeader"] = extra.get("noGRPCHeader", False)
+                    settings['xmux'] = extra.get('xmux',{})
+                    settings['downloadSettings'] = extra.get('downloadSettings',{})
                     settings["mode"] = net_settings.get("mode", "auto")
-                    settings["noGRPCHeader"] = net_settings.get("noGRPCHeader", False)
-                    settings["keepAlivePeriod"] = net_settings.get("keepAlivePeriod", 0)
+                    settings["keepAlivePeriod"] = net_settings.get("keepAlivePeriod", 0) #documentation says it's moved to hKeepAlivePeriod
 
                 elif net == 'kcp':
                     header = net_settings.get('header', {})


### PR DESCRIPTION
add real upload/download splitting to xhttp by adding downloadSettings in the extra.
the extra part is only for user but for the user to be able to get subscriptions with the extra part we have to use downloadSettings in our configuration in order to be able to send it to the user.

xmux is moved to extra
downloadSettings is moved to extra
keepalive was removed! ( there is a hKeepAlive... option inside xmux ).
subscription tested on v2rayng(android) and v2rayn(windows) and worked fine.
splitting tested and worked fine