### PR TITLE
fix: Disable openapi schema

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -16,8 +16,7 @@ app = FastAPI(
     title="MarzbanAPI",
     description="Unified GUI Censorship Resistant Solution Powered by Xray",
     version=__version__,
-    docs_url="/docs" if DOCS else None,
-    redoc_url="/redoc" if DOCS else None,
+    openapi_url="/openapi.json" if DOCS else None,
 )
 
 scheduler = BackgroundScheduler(


### PR DESCRIPTION
https://fastapi.tiangolo.com/tutorial/metadata/#openapi-url

> If you want to disable the OpenAPI schema completely you can set openapi_url=None, that will also disable the documentation user interfaces that use it.


Disabling /docs and /redoc does not disable the schema view on /openapi.json, but disabling /openapi.json also disables /docs and /redoc