### PR TITLE
Optional field data_limit and expire remove from dict in get_subscrip…

### DIFF
--- a/app/routers/subscription.py
+++ b/app/routers/subscription.py
@@ -37,12 +37,15 @@ router = APIRouter(tags=['Subscription'], prefix=f'/{XRAY_SUBSCRIPTION_PATH}')
 
 def get_subscription_user_info(user: UserResponse) -> dict:
     """Retrieve user subscription information including upload, download, total data, and expiry."""
-    return {
+    result_dict = {
         "upload": 0,
-        "download": user.used_traffic,
-        "total": user.data_limit if user.data_limit is not None else 0,
-        "expire": user.expire if user.expire is not None else 0,
+        "download": user.used_traffic
     }
+    if user.data_limit is not None:
+        result_dict["total"] = user.data_limit
+    if user.expire is not None:
+        result_dict["expire"] = user.expire
+    return result_dict
 
 
 @router.get("/{token}/")


### PR DESCRIPTION
Optional field data_limit and expire remove from dict in get_subscription_user_info if field None

Adding optional fields with a value of 0 to the output breaks the logic in cases where the user hasn’t configured their panel at all and hasn't provided the necessary parameters, as well as in cases where they explicitly specify that the traffic is unlimited.
For users who haven't configured anything, we don’t want to show any metadata at all.
And for those who have configured it, if they've used 0 traffic and have an unlimited plan, we want to display that the traffic is unlimited.
To distinguish between these two cases, the total field should not be sent if it doesn't exist.