### PR TITLE
Add User Management Features and Fix Core Config Modal

### DIFF
--- a/dashboard/public/statics/locales/en.json
+++ b/dashboard/public/statics/locales/en.json
@@ -543,7 +543,7 @@
   "resetUserUsage.title": "Reset User Usage",
   "revoke": "Revoke",
   "revokeUserSub.error": "Subscription revoke failed, please try again.",
-  "revokeUserSub.prompt": "Are you sure you want to revoke <b>{{username}}</b>'s subscription?",
+  "revokeUserSub.prompt": "Are you sure you want to revoke «{{username}}»'s subscription?",
   "revokeUserSub.success": "{{username}}'s subscription has revoked successfully.",
   "revokeUserSub.title": "Revoke User Subscription",
   "search": "Search",
@@ -807,5 +807,10 @@
   "statistics.activeUsers": "Active Users",
   "statistics.disabledUsers": "Disabled Users",
   "statistics.expiredUsers": "Expired Users",
-  "statistics.onHoldUsers": "On Hold Users"
+  "statistics.onHoldUsers": "On Hold Users",
+  "usersTable.resetUsageTitle": "Reset User Usage",
+  "usersTable.resetUsagePrompt": "Are you sure you want to reset the usage for «{{name}}»?",
+  "usersTable.resetUsageSubmit": "Reset Usage",
+  "usersTable.resetUsageSuccess": "User «{{name}}» usage has been reset successfully",
+  "usersTable.resetUsageFailed": "Failed to reset usage for user «{{name}}»"
 }

--- a/dashboard/public/statics/locales/fa.json
+++ b/dashboard/public/statics/locales/fa.json
@@ -494,7 +494,7 @@
   "resetUserUsage.title": "بازنشانی مصرف کاربر",
   "revoke": "بازنشانی",
   "revokeUserSub.error": "بازنشانی اشتراک انجام نشد، لطفاً دوباره امتحان کنید.",
-  "revokeUserSub.prompt": "آیا مطمئن هستید که می خواهید اشتراک <b>{{username}}</b> را بازنشانی کنید؟",
+  "revokeUserSub.prompt": "آیا مطمئن هستید که می خواهید اشتراک «{{username}}» را بازنشانی کنید؟",
   "revokeUserSub.success": "اشتراک {{username}} با موفقیت بازنشانی شد.",
   "revokeUserSub.title": "بازنشانی اشتراک کاربر",
   "search": "جستجو",
@@ -799,5 +799,10 @@
   "statistics.activeUsers": "کاربران فعال",
   "statistics.disabledUsers": "کاربران غیرفعال",
   "statistics.expiredUsers": "کاربران منقضی شده",
-  "statistics.onHoldUsers": "کاربران در انتظار"
+  "statistics.onHoldUsers": "کاربران در انتظار",
+  "usersTable.resetUsageTitle": "ریست مصرف کاربر",
+  "usersTable.resetUsagePrompt": "آیا مطمئن هستید که می‌خواهید مصرف «{{name}}» را ریست کنید؟",
+  "usersTable.resetUsageSubmit": "ریست مصرف",
+  "usersTable.resetUsageSuccess": "مصرف کاربر «{{name}}» با موفقیت ریست شد",
+  "usersTable.resetUsageFailed": "ریست مصرف کاربر «{{name}}» ناموفق بود"
 }

--- a/dashboard/public/statics/locales/ru.json
+++ b/dashboard/public/statics/locales/ru.json
@@ -329,7 +329,7 @@
   "resetUserUsage.title": "Сбросить расход трафика пользователя",
   "revoke": "Отозвать",
   "revokeUserSub.error": "Отзыв подписки не удался, пожалуйста, попробуйте ещё раз.",
-  "revokeUserSub.prompt": "Вы уверены, что хотите отозвать подписку для пользователя <b>{{username}}</b>?",
+  "revokeUserSub.prompt": "Вы уверены, что хотите отозвать подписку для пользователя «{{username}}»?",
   "revokeUserSub.success": "Подписка пользователя {{username}} успешно отозвана.",
   "revokeUserSub.title": "Отозвать подписку пользователя",
   "search": "Поиск",
@@ -802,5 +802,10 @@
   "statistics.activeUsers": "Активные пользователи",
   "statistics.disabledUsers": "Отключенные пользователи",
   "statistics.expiredUsers": "Истекшие пользователи",
-  "statistics.onHoldUsers": "Пользователи на удержании"
+  "statistics.onHoldUsers": "Пользователи на удержании",
+  "usersTable.resetUsageTitle": "Сбросить использование пользователя",
+  "usersTable.resetUsagePrompt": "Вы уверены, что хотите сбросить использование для «{{name}}»?",
+  "usersTable.resetUsageSubmit": "Сбросить использование",
+  "usersTable.resetUsageSuccess": "Использование пользователя «{{name}}» успешно сброшено",
+  "usersTable.resetUsageFailed": "Не удалось сбросить использование пользователя «{{name}}»"
 }

--- a/dashboard/public/statics/locales/zh.json
+++ b/dashboard/public/statics/locales/zh.json
@@ -331,7 +331,7 @@
   "resetUserUsage.title": "重置用户流量统计",
   "revoke": "撤销",
   "revokeUserSub.error": "撤销订阅失败，请稍候再试！",
-  "revokeUserSub.prompt": "您确定要撤销用户 <b>{{username}}</b> 的订阅吗？",
+  "revokeUserSub.prompt": "您确定要撤销用户 «{{username}}» 的订阅吗？",
   "revokeUserSub.success": "成功撤销用户 {{username}} 的订阅。",
   "revokeUserSub.title": "撤销用户订阅",
   "search": "搜索",
@@ -806,5 +806,10 @@
   "statistics.activeUsers": "活跃用户",
   "statistics.disabledUsers": "已禁用用户",
   "statistics.expiredUsers": "已过期用户",
-  "statistics.onHoldUsers": "暂停用户"
+  "statistics.onHoldUsers": "暂停用户",
+  "usersTable.resetUsageTitle": "重置用户使用情况",
+  "usersTable.resetUsagePrompt": "你确定要重置 «{{name}}» 的使用情况吗？",
+  "usersTable.resetUsageSubmit": "重置使用情况",
+  "usersTable.resetUsageSuccess": "用户「{{name}}」的使用情况已成功重置",
+  "usersTable.resetUsageFailed": "重置用户「{{name}}」的使用情况失败"
 }

--- a/dashboard/src/components/dialogs/CoreConfigModal.tsx
+++ b/dashboard/src/components/dialogs/CoreConfigModal.tsx
@@ -253,14 +253,22 @@ export default function CoreConfigModal({
     useEffect(() => {
         if (isDialogOpen) {
             if (!editingCore) {
-                // Set default values for new core
-                form.setValue("excluded_inbound_ids", []);
-                form.setValue("fallback_id", []);
-
-                if (!form.getValues().config) {
-                    form.setValue("config", defaultConfig);
-                }
+                // Reset form for new core
+                form.reset({
+                    name: '',
+                    config: defaultConfig,
+                    excluded_inbound_ids: [],
+                    fallback_id: []
+                });
             }
+        } else {
+            // Reset form when modal closes
+            form.reset({
+                name: '',
+                config: defaultConfig,
+                excluded_inbound_ids: [],
+                fallback_id: []
+            });
         }
     }, [isDialogOpen, editingCore, form, defaultConfig]);
 


### PR DESCRIPTION
## Changes
### User Management
- Added ability to revoke user subscriptions
- Added functionality to reset user usage statistics
- Added confirmation dialogs for both actions
- Added success/error toast notifications for operations

### Core Config Modal Fix
- Fixed issue where form fields were retaining data from previous edits when creating a new core configuration
- Improved form reset logic to properly clear all fields when modal closes
- Added proper form reset when switching between edit and create modes

## Technical Details
### User Management
- Added new API endpoints for revoking subscriptions and resetting usage
- Implemented confirmation dialogs with user-friendly messages
- Added proper error handling and success notifications
- Updated user interface to include new action buttons

### Core Config Modal
- Modified the `useEffect` hook in `CoreConfigModal.tsx` to handle form reset in both scenarios:
  1. When opening modal for new core creation
  2. When closing modal (regardless of edit/create mode)
- Replaced individual `setValue` calls with a single `form.reset()` call for more reliable field clearing
- Ensures clean state for new core creation by resetting all fields to default values
