### PR TITLE
fix: fix dialogs behavior in mobile and data limit 0 default and disable create if no groups, make group required

### DIFF
--- a/dashboard/public/statics/locales/en.json
+++ b/dashboard/public/statics/locales/en.json
@@ -543,7 +543,7 @@
   "resetUserUsage.title": "Reset User Usage",
   "revoke": "Revoke",
   "revokeUserSub.error": "Subscription revoke failed, please try again.",
-  "revokeUserSub.prompt": "Are you sure you want to revoke <b>{{username}}</b>'s subscription?",
+  "revokeUserSub.prompt": "Are you sure you want to revoke «{{username}}»'s subscription?",
   "revokeUserSub.success": "{{username}}'s subscription has revoked successfully.",
   "revokeUserSub.title": "Revoke User Subscription",
   "search": "Search",
@@ -807,5 +807,10 @@
   "statistics.activeUsers": "Active Users",
   "statistics.disabledUsers": "Disabled Users",
   "statistics.expiredUsers": "Expired Users",
-  "statistics.onHoldUsers": "On Hold Users"
+  "statistics.onHoldUsers": "On Hold Users",
+  "usersTable.resetUsageTitle": "Reset User Usage",
+  "usersTable.resetUsagePrompt": "Are you sure you want to reset the usage for «{{name}}»?",
+  "usersTable.resetUsageSubmit": "Reset Usage",
+  "usersTable.resetUsageSuccess": "User «{{name}}» usage has been reset successfully",
+  "usersTable.resetUsageFailed": "Failed to reset usage for user «{{name}}»"
 }

--- a/dashboard/public/statics/locales/fa.json
+++ b/dashboard/public/statics/locales/fa.json
@@ -494,7 +494,7 @@
   "resetUserUsage.title": "بازنشانی مصرف کاربر",
   "revoke": "بازنشانی",
   "revokeUserSub.error": "بازنشانی اشتراک انجام نشد، لطفاً دوباره امتحان کنید.",
-  "revokeUserSub.prompt": "آیا مطمئن هستید که می خواهید اشتراک <b>{{username}}</b> را بازنشانی کنید؟",
+  "revokeUserSub.prompt": "آیا مطمئن هستید که می خواهید اشتراک «{{username}}» را بازنشانی کنید؟",
   "revokeUserSub.success": "اشتراک {{username}} با موفقیت بازنشانی شد.",
   "revokeUserSub.title": "بازنشانی اشتراک کاربر",
   "search": "جستجو",
@@ -799,5 +799,10 @@
   "statistics.activeUsers": "کاربران فعال",
   "statistics.disabledUsers": "کاربران غیرفعال",
   "statistics.expiredUsers": "کاربران منقضی شده",
-  "statistics.onHoldUsers": "کاربران در انتظار"
+  "statistics.onHoldUsers": "کاربران در انتظار",
+  "usersTable.resetUsageTitle": "ریست مصرف کاربر",
+  "usersTable.resetUsagePrompt": "آیا مطمئن هستید که می‌خواهید مصرف «{{name}}» را ریست کنید؟",
+  "usersTable.resetUsageSubmit": "ریست مصرف",
+  "usersTable.resetUsageSuccess": "مصرف کاربر «{{name}}» با موفقیت ریست شد",
+  "usersTable.resetUsageFailed": "ریست مصرف کاربر «{{name}}» ناموفق بود"
 }

--- a/dashboard/public/statics/locales/ru.json
+++ b/dashboard/public/statics/locales/ru.json
@@ -329,7 +329,7 @@
   "resetUserUsage.title": "Сбросить расход трафика пользователя",
   "revoke": "Отозвать",
   "revokeUserSub.error": "Отзыв подписки не удался, пожалуйста, попробуйте ещё раз.",
-  "revokeUserSub.prompt": "Вы уверены, что хотите отозвать подписку для пользователя <b>{{username}}</b>?",
+  "revokeUserSub.prompt": "Вы уверены, что хотите отозвать подписку для пользователя «{{username}}»?",
   "revokeUserSub.success": "Подписка пользователя {{username}} успешно отозвана.",
   "revokeUserSub.title": "Отозвать подписку пользователя",
   "search": "Поиск",
@@ -802,5 +802,10 @@
   "statistics.activeUsers": "Активные пользователи",
   "statistics.disabledUsers": "Отключенные пользователи",
   "statistics.expiredUsers": "Истекшие пользователи",
-  "statistics.onHoldUsers": "Пользователи на удержании"
+  "statistics.onHoldUsers": "Пользователи на удержании",
+  "usersTable.resetUsageTitle": "Сбросить использование пользователя",
+  "usersTable.resetUsagePrompt": "Вы уверены, что хотите сбросить использование для «{{name}}»?",
+  "usersTable.resetUsageSubmit": "Сбросить использование",
+  "usersTable.resetUsageSuccess": "Использование пользователя «{{name}}» успешно сброшено",
+  "usersTable.resetUsageFailed": "Не удалось сбросить использование пользователя «{{name}}»"
 }

--- a/dashboard/public/statics/locales/zh.json
+++ b/dashboard/public/statics/locales/zh.json
@@ -331,7 +331,7 @@
   "resetUserUsage.title": "重置用户流量统计",
   "revoke": "撤销",
   "revokeUserSub.error": "撤销订阅失败，请稍候再试！",
-  "revokeUserSub.prompt": "您确定要撤销用户 <b>{{username}}</b> 的订阅吗？",
+  "revokeUserSub.prompt": "您确定要撤销用户 «{{username}}» 的订阅吗？",
   "revokeUserSub.success": "成功撤销用户 {{username}} 的订阅。",
   "revokeUserSub.title": "撤销用户订阅",
   "search": "搜索",
@@ -806,5 +806,10 @@
   "statistics.activeUsers": "活跃用户",
   "statistics.disabledUsers": "已禁用用户",
   "statistics.expiredUsers": "已过期用户",
-  "statistics.onHoldUsers": "暂停用户"
+  "statistics.onHoldUsers": "暂停用户",
+  "usersTable.resetUsageTitle": "重置用户使用情况",
+  "usersTable.resetUsagePrompt": "你确定要重置 «{{name}}» 的使用情况吗？",
+  "usersTable.resetUsageSubmit": "重置使用情况",
+  "usersTable.resetUsageSuccess": "用户「{{name}}」的使用情况已成功重置",
+  "usersTable.resetUsageFailed": "重置用户「{{name}}」的使用情况失败"
 }

--- a/dashboard/src/components/dialogs/AdminModal.tsx
+++ b/dashboard/src/components/dialogs/AdminModal.tsx
@@ -193,7 +193,7 @@ export default function AdminModal({
                 <Form {...form}>
                     <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
                         <div
-                            className="max-h-[85vh] overflow-y-auto pr-4 -mr-4 sm:max-h-[75vh] px-2">
+                            className="max-h-[80vh] overflow-y-auto pr-4 -mr-4 sm:max-h-[75vh] px-2">
                             <div className="flex flex-col sm:flex-row items-start gap-4 pb-4">
                                 <div className="flex-1 space-y-4 w-full">
                                     {!editingAdmin &&

--- a/dashboard/src/components/dialogs/CoreConfigModal.tsx
+++ b/dashboard/src/components/dialogs/CoreConfigModal.tsx
@@ -253,14 +253,22 @@ export default function CoreConfigModal({
     useEffect(() => {
         if (isDialogOpen) {
             if (!editingCore) {
-                // Set default values for new core
-                form.setValue("excluded_inbound_ids", []);
-                form.setValue("fallback_id", []);
-
-                if (!form.getValues().config) {
-                    form.setValue("config", defaultConfig);
-                }
+                // Reset form for new core
+                form.reset({
+                    name: '',
+                    config: defaultConfig,
+                    excluded_inbound_ids: [],
+                    fallback_id: []
+                });
             }
+        } else {
+            // Reset form when modal closes
+            form.reset({
+                name: '',
+                config: defaultConfig,
+                excluded_inbound_ids: [],
+                fallback_id: []
+            });
         }
     }, [isDialogOpen, editingCore, form, defaultConfig]);
 

--- a/dashboard/src/components/dialogs/CoreConfigModal.tsx
+++ b/dashboard/src/components/dialogs/CoreConfigModal.tsx
@@ -1,23 +1,23 @@
-import {Dialog, DialogContent, DialogHeader, DialogTitle} from '@/components/ui/dialog'
-import {Form, FormControl, FormField, FormItem, FormLabel, FormMessage} from '@/components/ui/form'
-import {Input} from '@/components/ui/input'
-import {Button} from '@/components/ui/button'
-import {useTranslation} from 'react-i18next'
-import {UseFormReturn} from 'react-hook-form'
-import {toast} from '@/hooks/use-toast'
-import {z} from 'zod'
-import {cn} from '@/lib/utils'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { useTranslation } from 'react-i18next'
+import { UseFormReturn } from 'react-hook-form'
+import { toast } from '@/hooks/use-toast'
+import { z } from 'zod'
+import { cn } from '@/lib/utils'
 import useDirDetection from '@/hooks/use-dir-detection'
-import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from '@/components/ui/select'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import Editor from '@monaco-editor/react'
-import {useTheme} from '../../components/theme-provider'
-import {useCallback, useState, useEffect} from 'react'
-import {X, Maximize2, Minimize2} from 'lucide-react'
-import {useCreateCoreConfig, useModifyCoreConfig} from '@/service/api'
-import {queryClient} from '@/utils/query-client'
-import {CopyButton} from '@/components/CopyButton'
-import {generateKeyPair} from '@stablelib/x25519'
-import {encodeURLSafe} from '@stablelib/base64'
+import { useTheme } from '../../components/theme-provider'
+import { useCallback, useState, useEffect } from 'react'
+import { X, Maximize2, Minimize2 } from 'lucide-react'
+import { useCreateCoreConfig, useModifyCoreConfig } from '@/service/api'
+import { queryClient } from '@/utils/query-client'
+import { CopyButton } from '@/components/CopyButton'
+import { generateKeyPair } from '@stablelib/x25519'
+import { encodeURLSafe } from '@stablelib/base64'
 
 export const coreConfigFormSchema = z.object({
     name: z.string().min(1, 'Name is required'),
@@ -44,16 +44,16 @@ interface ValidationResult {
 }
 
 export default function CoreConfigModal({
-                                            isDialogOpen,
-                                            onOpenChange,
-                                            form,
-                                            editingCore,
-                                            editingCoreId
-                                        }: CoreConfigModalProps) {
-    const {t} = useTranslation()
+    isDialogOpen,
+    onOpenChange,
+    form,
+    editingCore,
+    editingCoreId
+}: CoreConfigModalProps) {
+    const { t } = useTranslation()
     const dir = useDirDetection()
-    const {resolvedTheme} = useTheme()
-    const [validation, setValidation] = useState<ValidationResult>({isValid: true})
+    const { resolvedTheme } = useTheme()
+    const [validation, setValidation] = useState<ValidationResult>({ isValid: true })
     const [isEditorReady, setIsEditorReady] = useState(false)
     const [generatedShortId, setGeneratedShortId] = useState<string | null>(null)
     const [keyPair, setKeyPair] = useState<{ publicKey: string, privateKey: string } | null>(null)
@@ -76,7 +76,7 @@ export default function CoreConfigModal({
                 try {
                     // Additional validation - try parsing the JSON
                     JSON.parse(form.getValues().config)
-                    setValidation({isValid: true})
+                    setValidation({ isValid: true })
                 } catch (e) {
                     setValidation({
                         isValid: false,
@@ -155,7 +155,7 @@ export default function CoreConfigModal({
                 configObj = JSON.parse(values.config)
             } catch (e) {
                 toast({
-                    title: t('error', {defaultValue: 'Error'}),
+                    title: t('error', { defaultValue: 'Error' }),
                     description: t('coreConfigModal.invalidJson'),
                     variant: "destructive"
                 })
@@ -199,7 +199,7 @@ export default function CoreConfigModal({
             }
 
             toast({
-                title: t('success', {defaultValue: 'Success'}),
+                title: t('success', { defaultValue: 'Success' }),
                 description: t(editingCore ? 'coreConfigModal.editSuccess' : 'coreConfigModal.createSuccess', {
                     name: values.name,
                     defaultValue: editingCore
@@ -209,14 +209,14 @@ export default function CoreConfigModal({
             })
 
             // Invalidate cores query to refresh list
-            queryClient.invalidateQueries({queryKey: ['/api/cores']})
+            queryClient.invalidateQueries({ queryKey: ['/api/cores'] })
 
             onOpenChange(false)
             form.reset()
         } catch (error: any) {
             console.error('Core config operation failed:', error)
             toast({
-                title: t('error', {defaultValue: 'Error'}),
+                title: t('error', { defaultValue: 'Error' }),
                 description: t(editingCore ? 'coreConfigModal.editFailed' : 'coreConfigModal.createFailed', {
                     name: values.name,
                     error: error?.message || '',
@@ -293,7 +293,7 @@ export default function CoreConfigModal({
                 <Form {...form}>
                     <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
                         <div
-                            className="max-h-[75vh] overflow-y-auto pr-4 -mr-4 sm:max-h-[75vh] px-2">
+                            className="max-h-[75vh] overflow-y-auto pr-4 -mr-4 px-2">
                             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                                 <div>
                                     <h3 className="text-lg font-semibold mb-4">{t('coreConfigModal.jsonConfig')}</h3>
@@ -302,7 +302,7 @@ export default function CoreConfigModal({
                                         <FormField
                                             control={form.control}
                                             name="config"
-                                            render={({field}) => (
+                                            render={({ field }) => (
                                                 <FormItem>
                                                     <FormControl>
                                                         <div className={cn(
@@ -313,8 +313,8 @@ export default function CoreConfigModal({
                                                             {!isEditorReady && (
                                                                 <div
                                                                     className="absolute inset-0 flex items-center justify-center bg-background/80 z-50">
-                                        <span
-                                            className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-primary"></span>
+                                                                    <span
+                                                                        className="animate-spin rounded-full h-8 w-8 border-t-2 border-b-2 border-primary"></span>
                                                                 </div>
                                                             )}
                                                             {/* Fullscreen Toggle Button */}
@@ -327,10 +327,10 @@ export default function CoreConfigModal({
                                                                     isEditorFullscreen ? "bg-muted" : ""
                                                                 )}
                                                                 onClick={() => setIsEditorFullscreen((v) => !v)}
-                                                                aria-label={isEditorFullscreen ? t('exitFullscreen', {defaultValue: 'Exit Fullscreen'}) : t('fullscreen', {defaultValue: 'Fullscreen'})}
+                                                                aria-label={isEditorFullscreen ? t('exitFullscreen', { defaultValue: 'Exit Fullscreen' }) : t('fullscreen', { defaultValue: 'Fullscreen' })}
                                                             >
-                                                                {isEditorFullscreen ? <Minimize2 className="h-5 w-5"/> :
-                                                                    <Maximize2 className="h-5 w-5"/>}
+                                                                {isEditorFullscreen ? <Minimize2 className="h-5 w-5" /> :
+                                                                    <Maximize2 className="h-5 w-5" />}
                                                             </Button>
                                                             <Editor
                                                                 height={isEditorFullscreen ? "100vh" : "100%"}
@@ -341,7 +341,7 @@ export default function CoreConfigModal({
                                                                 onValidate={handleEditorValidation}
                                                                 onMount={handleEditorDidMount}
                                                                 options={{
-                                                                    minimap: {enabled: false},
+                                                                    minimap: { enabled: false },
                                                                     fontSize: 14,
                                                                     lineNumbers: 'on',
                                                                     roundedSelection: true,
@@ -366,14 +366,14 @@ export default function CoreConfigModal({
                                     <FormField
                                         control={form.control}
                                         name="name"
-                                        render={({field}) => (
+                                        render={({ field }) => (
                                             <FormItem>
                                                 <FormLabel>{t('coreConfigModal.name')}</FormLabel>
                                                 <FormControl>
                                                     <Input
                                                         placeholder={t('coreConfigModal.namePlaceholder')} {...field} />
                                                 </FormControl>
-                                                <FormMessage/>
+                                                <FormMessage />
                                             </FormItem>
                                         )}
                                     />
@@ -381,7 +381,7 @@ export default function CoreConfigModal({
                                     <FormField
                                         control={form.control}
                                         name="fallback_id"
-                                        render={({field}) => (
+                                        render={({ field }) => (
                                             <FormItem>
                                                 <FormLabel>{t('coreConfigModal.fallback')}</FormLabel>
                                                 <div className="flex flex-col gap-2">
@@ -389,16 +389,16 @@ export default function CoreConfigModal({
                                                         {field.value && field.value.length > 0 ? (
                                                             field.value.map((tag: string) => (
                                                                 <span key={tag}
-                                                                      className="bg-muted/80 px-2 py-1 rounded-md text-sm flex items-center gap-2">
-                                {tag}
+                                                                    className="bg-muted/80 px-2 py-1 rounded-md text-sm flex items-center gap-2">
+                                                                    {tag}
                                                                     <button
                                                                         type="button"
                                                                         className="hover:text-destructive"
                                                                         onClick={() => field.onChange((field.value || []).filter((t: string) => t !== tag))}
                                                                     >
-                                  ×
-                                </button>
-                              </span>
+                                                                        ×
+                                                                    </button>
+                                                                </span>
                                                             ))
                                                         ) : (
                                                             <span
@@ -418,7 +418,7 @@ export default function CoreConfigModal({
                                                         <FormControl>
                                                             <SelectTrigger>
                                                                 <SelectValue
-                                                                    placeholder={t('coreConfigModal.selectFallback')}/>
+                                                                    placeholder={t('coreConfigModal.selectFallback')} />
                                                             </SelectTrigger>
                                                         </FormControl>
                                                         <SelectContent>
@@ -451,7 +451,7 @@ export default function CoreConfigModal({
                                                         </Button>
                                                     )}
                                                 </div>
-                                                <FormMessage/>
+                                                <FormMessage />
                                             </FormItem>
                                         )}
                                     />
@@ -459,7 +459,7 @@ export default function CoreConfigModal({
                                     <FormField
                                         control={form.control}
                                         name="excluded_inbound_ids"
-                                        render={({field}) => (
+                                        render={({ field }) => (
                                             <FormItem>
                                                 <FormLabel>{t('coreConfigModal.excludedInbound')}</FormLabel>
                                                 <div className="flex flex-col gap-2">
@@ -467,16 +467,16 @@ export default function CoreConfigModal({
                                                         {field.value && field.value.length > 0 ? (
                                                             field.value.map((tag: string) => (
                                                                 <span key={tag}
-                                                                      className="bg-muted/80 px-2 py-1 rounded-md text-sm flex items-center gap-2">
-                                {tag}
+                                                                    className="bg-muted/80 px-2 py-1 rounded-md text-sm flex items-center gap-2">
+                                                                    {tag}
                                                                     <button
                                                                         type="button"
                                                                         className="hover:text-destructive"
                                                                         onClick={() => field.onChange((field.value || []).filter((t: string) => t !== tag))}
                                                                     >
-                                  ×
-                                </button>
-                              </span>
+                                                                        ×
+                                                                    </button>
+                                                                </span>
                                                             ))
                                                         ) : (
                                                             <span
@@ -496,7 +496,7 @@ export default function CoreConfigModal({
                                                         <FormControl>
                                                             <SelectTrigger>
                                                                 <SelectValue
-                                                                    placeholder={t('coreConfigModal.selectInbound')}/>
+                                                                    placeholder={t('coreConfigModal.selectInbound')} />
                                                             </SelectTrigger>
                                                         </FormControl>
                                                         <SelectContent>
@@ -529,7 +529,7 @@ export default function CoreConfigModal({
                                                         </Button>
                                                     )}
                                                 </div>
-                                                <FormMessage/>
+                                                <FormMessage />
                                             </FormItem>
                                         )}
                                     />
@@ -551,7 +551,7 @@ export default function CoreConfigModal({
                                                     onClick={() => setKeyPair(null)}
                                                     aria-label={t('close')}
                                                 >
-                                                    <X className="h-4 w-4"/>
+                                                    <X className="h-4 w-4" />
                                                 </Button>
 
                                                 <div className="space-y-3">
@@ -607,7 +607,7 @@ export default function CoreConfigModal({
                                                 onClick={() => setGeneratedShortId(null)}
                                                 aria-label={t('close')}
                                             >
-                                                <X className="h-4 w-4"/>
+                                                <X className="h-4 w-4" />
                                             </Button>
                                             <p className="text-sm font-medium mb-1">{t('coreConfigModal.shortId')}</p>
                                             <div className="flex items-center gap-2">
@@ -627,7 +627,7 @@ export default function CoreConfigModal({
                             </div>
                         </div>
                         {!isEditorFullscreen && (
-                            <div className="flex justify-end gap-x-2 pt-4">
+                            <div className="flex justify-end gap-2">
                                 <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
                                     {t('cancel')}
                                 </Button>

--- a/dashboard/src/components/dialogs/GroupModal.tsx
+++ b/dashboard/src/components/dialogs/GroupModal.tsx
@@ -12,7 +12,7 @@ import { Badge } from '@/components/ui/badge'
 import { X } from 'lucide-react'
 import { cn } from '@/lib/utils'
 import { queryClient } from '@/utils/query-client'
-
+import useDirDetection from '@/hooks/use-dir-detection'
 export const groupFormSchema = z.object({
   name: z.string().min(1, 'Name is required'),
   inbound_tags: z.array(z.string()),
@@ -31,6 +31,7 @@ interface GroupModalProps {
 
 export default function GroupModal({ isDialogOpen, onOpenChange, form, editingGroup, editingGroupId }: GroupModalProps) {
   const { t } = useTranslation()
+  const dir = useDirDetection()
   const addGroupMutation = useCreateGroup()
   const modifyGroupMutation = useModifyGroup()
   const { data: inbounds } = useGetInbounds()
@@ -44,7 +45,7 @@ export default function GroupModal({ isDialogOpen, onOpenChange, form, editingGr
         })
         toast({
           title: t('success', { defaultValue: 'Success' }),
-          description: t('group.editSuccess', { 
+          description: t('group.editSuccess', {
             name: values.name,
             defaultValue: 'Group "{name}" has been updated successfully'
           })
@@ -55,7 +56,7 @@ export default function GroupModal({ isDialogOpen, onOpenChange, form, editingGr
         })
         toast({
           title: t('success', { defaultValue: 'Success' }),
-          description: t('group.createSuccess', { 
+          description: t('group.createSuccess', {
             name: values.name,
             defaultValue: 'Group "{name}" has been created successfully'
           })
@@ -69,7 +70,7 @@ export default function GroupModal({ isDialogOpen, onOpenChange, form, editingGr
       console.error('Group operation failed:', error)
       toast({
         title: t('error', { defaultValue: 'Error' }),
-        description: t(editingGroup ? 'group.editFailed' : 'group.createFailed', { 
+        description: t(editingGroup ? 'group.editFailed' : 'group.createFailed', {
           name: values.name,
           error: error?.message || '',
           defaultValue: `Failed to ${editingGroup ? 'update' : 'create'} group "{name}". {error}`
@@ -83,7 +84,7 @@ export default function GroupModal({ isDialogOpen, onOpenChange, form, editingGr
     <Dialog open={isDialogOpen} onOpenChange={onOpenChange}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>{editingGroup ? t('editGroup', { defaultValue: 'Edit Group' }) : t('createGroup')}</DialogTitle>
+          <DialogTitle className={cn(dir === 'rtl' && 'text-right')}>{editingGroup ? t('editGroup', { defaultValue: 'Edit Group' }) : t('createGroup')}</DialogTitle>
         </DialogHeader>
         <Form {...form}>
           <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
@@ -159,8 +160,8 @@ export default function GroupModal({ isDialogOpen, onOpenChange, form, editingGr
               <Button variant="outline" onClick={() => onOpenChange(false)}>
                 {t('cancel')}
               </Button>
-              <Button 
-                type="submit" 
+              <Button
+                type="submit"
                 disabled={addGroupMutation.isPending || modifyGroupMutation.isPending}
                 className="bg-primary hover:bg-primary/90"
               >

--- a/dashboard/src/components/dialogs/HostModal.tsx
+++ b/dashboard/src/components/dialogs/HostModal.tsx
@@ -161,1185 +161,1476 @@ const HostModal: React.FC<HostModalProps> = ({
                 </DialogHeader>
                 <Form {...form}>
                     <form onSubmit={form.handleSubmit(handleSubmit)} className="space-y-4">
-                        <FormField
-                            control={form.control}
-                            name="inbound_tag"
-                            render={({ field }) => (
-                                <FormItem>
-                                    <FormLabel>{t("inbound")}</FormLabel>
-                                    <Select dir={dir} onValueChange={field.onChange} value={field.value}>
-                                        <FormControl>
-                                            <SelectTrigger className="py-5">
-                                                <SelectValue placeholder={t("hostsDialog.selectInbound")} />
-                                            </SelectTrigger>
-                                        </FormControl>
-                                        <SelectContent dir="ltr">
-                                            {inbounds.map((tag) => (
-                                                <SelectItem className="px-4 cursor-pointer" value={tag} key={tag}>{tag}</SelectItem>
-                                            ))}
-                                        </SelectContent>
-                                    </Select>
-                                    <FormMessage />
-                                </FormItem>
-                            )}
-                        />
-
-                        <FormField
-                            control={form.control}
-                            name="status"
-                            render={({ field }) => (
-                                <FormItem>
-                                    <FormLabel>{t("hostsDialog.status.label")}</FormLabel>
-                                    <div className="flex flex-col gap-2">
-                                        <div className="flex flex-wrap gap-1">
-                                            {field.value && field.value.length > 0 ? (
-                                                field.value.map((status) => {
-                                                    const option = statusOptions.find(opt => opt.value === status);
-                                                    if (!option) return null;
-                                                    return (
-                                                        <span key={status} className="bg-muted/80 px-2 py-1 rounded-md text-sm flex items-center gap-2">
-                                                            {t(option.label)}
-                                                            <button
-                                                                type="button"
-                                                                className="hover:text-destructive"
-                                                                onClick={() => {
-                                                                    field.onChange(field.value.filter(s => s !== status));
-                                                                }}
-                                                            >
-                                                                ×
-                                                            </button>
-                                                        </span>
-                                                    );
-                                                })
-                                            ) : (
-                                                <span className="text-muted-foreground text-sm">{t("hostsDialog.noStatus")}</span>
-                                            )}
-                                        </div>
-                                        <Select
-                                            value=""
-                                            onValueChange={(value: UserStatus) => {
-                                                if (!value) return;
-                                                const currentValue = field.value || [];
-                                                if (!currentValue.includes(value)) {
-                                                    field.onChange([...currentValue, value]);
-                                                }
-                                            }}
-                                        >
+                        <div
+                            className="max-h-[80vh] sm:max-h-[75vh] overflow-y-auto pr-4 -mr-4 px-2 space-y-4">
+                            <FormField
+                                control={form.control}
+                                name="inbound_tag"
+                                render={({ field }) => (
+                                    <FormItem>
+                                        <FormLabel>{t("inbound")}</FormLabel>
+                                        <Select dir={dir} onValueChange={field.onChange} value={field.value}>
                                             <FormControl>
-                                                <SelectTrigger dir={dir} className="w-full py-5">
-                                                    <SelectValue placeholder={t("hostsDialog.selectStatus")} />
+                                                <SelectTrigger className="py-5">
+                                                    <SelectValue placeholder={t("hostsDialog.selectInbound")} />
                                                 </SelectTrigger>
                                             </FormControl>
-                                            <SelectContent dir={dir} className="bg-background">
-                                                {statusOptions.map((option) => (
-                                                    <SelectItem
-                                                        key={option.value}
-                                                        value={option.value}
-                                                        className="flex items-center gap-2 py-2 px-4 cursor-pointer focus:bg-accent"
-                                                        disabled={field.value?.includes(option.value)}
-                                                    >
-                                                        <div className="flex items-center gap-3 w-full">
-                                                            <Checkbox
-                                                                checked={field.value?.includes(option.value)}
-                                                                className="h-4 w-4"
-                                                            />
-                                                            <span className="font-normal text-sm">{t(option.label)}</span>
-                                                        </div>
-                                                    </SelectItem>
+                                            <SelectContent dir="ltr">
+                                                {inbounds.map((tag) => (
+                                                    <SelectItem className="px-4 cursor-pointer" value={tag} key={tag}>{tag}</SelectItem>
                                                 ))}
                                             </SelectContent>
                                         </Select>
-                                        {field.value && field.value.length > 0 && (
-                                            <Button
-                                                type="button"
-                                                variant="outline"
-                                                size="sm"
-                                                onClick={() => field.onChange([])}
-                                                className="w-full"
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+
+                            <FormField
+                                control={form.control}
+                                name="status"
+                                render={({ field }) => (
+                                    <FormItem>
+                                        <FormLabel>{t("hostsDialog.status.label")}</FormLabel>
+                                        <div className="flex flex-col gap-2">
+                                            <div className="flex flex-wrap gap-1">
+                                                {field.value && field.value.length > 0 ? (
+                                                    field.value.map((status) => {
+                                                        const option = statusOptions.find(opt => opt.value === status);
+                                                        if (!option) return null;
+                                                        return (
+                                                            <span key={status} className="bg-muted/80 px-2 py-1 rounded-md text-sm flex items-center gap-2">
+                                                                {t(option.label)}
+                                                                <button
+                                                                    type="button"
+                                                                    className="hover:text-destructive"
+                                                                    onClick={() => {
+                                                                        field.onChange(field.value.filter(s => s !== status));
+                                                                    }}
+                                                                >
+                                                                    ×
+                                                                </button>
+                                                            </span>
+                                                        );
+                                                    })
+                                                ) : (
+                                                    <span className="text-muted-foreground text-sm">{t("hostsDialog.noStatus")}</span>
+                                                )}
+                                            </div>
+                                            <Select
+                                                value=""
+                                                onValueChange={(value: UserStatus) => {
+                                                    if (!value) return;
+                                                    const currentValue = field.value || [];
+                                                    if (!currentValue.includes(value)) {
+                                                        field.onChange([...currentValue, value]);
+                                                    }
+                                                }}
                                             >
-                                                {t("hostsDialog.clearAllStatuses")}
-                                            </Button>
-                                        )}
-                                    </div>
-                                    <FormMessage />
-                                </FormItem>
-                            )}
-                        />
-
-                        <FormField
-                            control={form.control}
-                            name="remark"
-                            render={({ field }) => (
-                                <FormItem>
-                                    <div className="flex items-center gap-2">
-                                        <FormLabel>{t("remark")}</FormLabel>
-                                        <Popover>
-                                            <PopoverTrigger asChild>
-                                                <Button
-                                                    type="button"
-                                                    variant="ghost"
-                                                    size="icon"
-                                                    className="h-4 w-4 p-0 hover:bg-transparent"
-                                                >
-                                                    <Info className="h-4 w-4 text-muted-foreground" />
-                                                </Button>
-                                            </PopoverTrigger>
-                                            <PopoverContent
-                                                className="w-[320px] p-3"
-                                                side="right"
-                                                align="start"
-                                            >
-                                                <div className="space-y-1.5">
-                                                    <h4 className="font-medium text-[12px] mb-2">{t("hostsDialog.variables.title")}</h4>
-                                                    <div className="space-y-1">
-                                                        <div className="flex items-center gap-1.5">
-                                                            <code className="text-[11px] bg-muted/50 px-1.5 py-0.5 rounded-sm">{"{SERVER_IP}"}</code>
-                                                            <span className="text-[11px] text-muted-foreground">{t("hostsDialog.variables.server_ip")}</span>
-                                                        </div>
-                                                        <div className="flex items-center gap-1.5">
-                                                            <code className="text-[11px] bg-muted/50 px-1.5 py-0.5 rounded-sm">{"{SERVER_IPV6}"}</code>
-                                                            <span className="text-[11px] text-muted-foreground">{t("hostsDialog.variables.server_ipv6")}</span>
-                                                        </div>
-                                                        <div className="flex items-center gap-1.5">
-                                                            <code className="text-[11px] bg-muted/50 px-1.5 py-0.5 rounded-sm">{"{USERNAME}"}</code>
-                                                            <span className="text-[11px] text-muted-foreground">{t("hostsDialog.variables.username")}</span>
-                                                        </div>
-                                                        <div className="flex items-center gap-1.5">
-                                                            <code className="text-[11px] bg-muted/50 px-1.5 py-0.5 rounded-sm">{"{DATA_USAGE}"}</code>
-                                                            <span className="text-[11px] text-muted-foreground">{t("hostsDialog.variables.data_usage")}</span>
-                                                        </div>
-                                                        <div className="flex items-center gap-1.5">
-                                                            <code className="text-[11px] bg-muted/50 px-1.5 py-0.5 rounded-sm">{"{DATA_LEFT}"}</code>
-                                                            <span className="text-[11px] text-muted-foreground">{t("hostsDialog.variables.data_left")}</span>
-                                                        </div>
-                                                        <div className="flex items-center gap-1.5">
-                                                            <code className="text-[11px] bg-muted/50 px-1.5 py-0.5 rounded-sm">{"{DATA_LIMIT}"}</code>
-                                                            <span className="text-[11px] text-muted-foreground">{t("hostsDialog.variables.data_limit")}</span>
-                                                        </div>
-                                                        <div className="flex items-center gap-1.5">
-                                                            <code className="text-[11px] bg-muted/50 px-1.5 py-0.5 rounded-sm">{"{DAYS_LEFT}"}</code>
-                                                            <span className="text-[11px] text-muted-foreground">{t("hostsDialog.variables.days_left")}</span>
-                                                        </div>
-                                                        <div className="flex items-center gap-1.5">
-                                                            <code className="text-[11px] bg-muted/50 px-1.5 py-0.5 rounded-sm">{"{EXPIRE_DATE}"}</code>
-                                                            <span className="text-[11px] text-muted-foreground">{t("hostsDialog.variables.expire_date")}</span>
-                                                        </div>
-                                                        <div className="flex items-center gap-1.5">
-                                                            <code className="text-[11px] bg-muted/50 px-1.5 py-0.5 rounded-sm">{"{JALALI_EXPIRE_DATE}"}</code>
-                                                            <span className="text-[11px] text-muted-foreground">{t("hostsDialog.variables.jalali_expire_date")}</span>
-                                                        </div>
-                                                        <div className="flex items-center gap-1.5">
-                                                            <code className="text-[11px] bg-muted/50 px-1.5 py-0.5 rounded-sm">{"{TIME_LEFT}"}</code>
-                                                            <span className="text-[11px] text-muted-foreground">{t("hostsDialog.variables.time_left")}</span>
-                                                        </div>
-                                                        <div className="flex items-center gap-1.5">
-                                                            <code className="text-[11px] bg-muted/50 px-1.5 py-0.5 rounded-sm">{"{STATUS_TEXT}"}</code>
-                                                            <span className="text-[11px] text-muted-foreground">{t("hostsDialog.variables.status_text")}</span>
-                                                        </div>
-                                                        <div className="flex items-center gap-1.5">
-                                                            <code className="text-[11px] bg-muted/50 px-1.5 py-0.5 rounded-sm">{"{STATUS_EMOJI}"}</code>
-                                                            <span className="text-[11px] text-muted-foreground">{t("hostsDialog.variables.status_emoji")}</span>
-                                                        </div>
-                                                        <div className="flex items-center gap-1.5">
-                                                            <code className="text-[11px] bg-muted/50 px-1.5 py-0.5 rounded-sm">{"{PROTOCOL}"}</code>
-                                                            <span className="text-[11px] text-muted-foreground">{t("hostsDialog.variables.protocol")}</span>
-                                                        </div>
-                                                        <div className="flex items-center gap-1.5">
-                                                            <code className="text-[11px] bg-muted/50 px-1.5 py-0.5 rounded-sm">{"{TRANSPORT}"}</code>
-                                                            <span className="text-[11px] text-muted-foreground">{t("hostsDialog.variables.transport")}</span>
-                                                        </div>
-                                                    </div>
-                                                </div>
-                                            </PopoverContent>
-                                        </Popover>
-                                    </div>
-                                    <FormControl>
-                                        <Input placeholder="Remark (e.g. Marzban-Host)" {...field} />
-                                    </FormControl>
-                                    <FormMessage />
-                                </FormItem>
-                            )}
-                        />
-
-                        <div className="flex items-center gap-4 justify-between">
-                            <div className="flex-[2]">
-                                <FormField
-                                    control={form.control}
-                                    name="address"
-                                    render={({ field }) => (
-                                        <FormItem>
-                                            <div className="flex items-center gap-2">
-
-                                                <FormLabel>{t("hostsDialog.address")}</FormLabel>
-                                                <Popover>
-                                                    <PopoverTrigger asChild>
-                                                        <Button
-                                                            type="button"
-                                                            variant="ghost"
-                                                            size="icon"
-                                                            className="h-4 w-4 p-0 hover:bg-transparent"
+                                                <FormControl>
+                                                    <SelectTrigger dir={dir} className="w-full py-5">
+                                                        <SelectValue placeholder={t("hostsDialog.selectStatus")} />
+                                                    </SelectTrigger>
+                                                </FormControl>
+                                                <SelectContent dir={dir} className="bg-background">
+                                                    {statusOptions.map((option) => (
+                                                        <SelectItem
+                                                            key={option.value}
+                                                            value={option.value}
+                                                            className="flex items-center gap-2 py-2 px-4 cursor-pointer focus:bg-accent"
+                                                            disabled={field.value?.includes(option.value)}
                                                         >
-                                                            <Info className="h-4 w-4 text-muted-foreground" />
-                                                        </Button>
-                                                    </PopoverTrigger>
-                                                    <PopoverContent
-                                                        className="w-[320px] p-3"
-                                                        side="right"
-                                                        align="start"
-                                                        sideOffset={5}
-                                                    >
-                                                        <div className="space-y-1.5">
-                                                            <h4 className="font-medium text-[12px] mb-2">{t("hostsDialog.variables.title")}</h4>
-                                                            <div className="space-y-1">
-                                                                <div className="flex items-center gap-1.5">
-                                                                    <code className="text-[11px] bg-muted/50 px-1.5 py-0.5 rounded-sm">{"{SERVER_IP}"}</code>
-                                                                    <span className="text-[11px] text-muted-foreground">{t("hostsDialog.variables.server_ip")}</span>
-                                                                </div>
-                                                                <div className="flex items-center gap-1.5">
-                                                                    <code className="text-[11px] bg-muted/50 px-1.5 py-0.5 rounded-sm">{"{SERVER_IPV6}"}</code>
-                                                                    <span className="text-[11px] text-muted-foreground">{t("hostsDialog.variables.server_ipv6")}</span>
-                                                                </div>
-                                                                <div className="flex items-center gap-1.5">
-                                                                    <code className="text-[11px] bg-muted/50 px-1.5 py-0.5 rounded-sm">{"{USERNAME}"}</code>
-                                                                    <span className="text-[11px] text-muted-foreground">{t("hostsDialog.variables.username")}</span>
-                                                                </div>
-                                                                <div className="flex items-center gap-1.5">
-                                                                    <code className="text-[11px] bg-muted/50 px-1.5 py-0.5 rounded-sm">{"{DATA_USAGE}"}</code>
-                                                                    <span className="text-[11px] text-muted-foreground">{t("hostsDialog.variables.data_usage")}</span>
-                                                                </div>
-                                                                <div className="flex items-center gap-1.5">
-                                                                    <code className="text-[11px] bg-muted/50 px-1.5 py-0.5 rounded-sm">{"{DATA_LEFT}"}</code>
-                                                                    <span className="text-[11px] text-muted-foreground">{t("hostsDialog.variables.data_left")}</span>
-                                                                </div>
-                                                                <div className="flex items-center gap-1.5">
-                                                                    <code className="text-[11px] bg-muted/50 px-1.5 py-0.5 rounded-sm">{"{DATA_LIMIT}"}</code>
-                                                                    <span className="text-[11px] text-muted-foreground">{t("hostsDialog.variables.data_limit")}</span>
-                                                                </div>
-                                                                <div className="flex items-center gap-1.5">
-                                                                    <code className="text-[11px] bg-muted/50 px-1.5 py-0.5 rounded-sm">{"{DAYS_LEFT}"}</code>
-                                                                    <span className="text-[11px] text-muted-foreground">{t("hostsDialog.variables.days_left")}</span>
-                                                                </div>
-                                                                <div className="flex items-center gap-1.5">
-                                                                    <code className="text-[11px] bg-muted/50 px-1.5 py-0.5 rounded-sm">{"{EXPIRE_DATE}"}</code>
-                                                                    <span className="text-[11px] text-muted-foreground">{t("hostsDialog.variables.expire_date")}</span>
-                                                                </div>
-                                                                <div className="flex items-center gap-1.5">
-                                                                    <code className="text-[11px] bg-muted/50 px-1.5 py-0.5 rounded-sm">{"{JALALI_EXPIRE_DATE}"}</code>
-                                                                    <span className="text-[11px] text-muted-foreground">{t("hostsDialog.variables.jalali_expire_date")}</span>
-                                                                </div>
-                                                                <div className="flex items-center gap-1.5">
-                                                                    <code className="text-[11px] bg-muted/50 px-1.5 py-0.5 rounded-sm">{"{TIME_LEFT}"}</code>
-                                                                    <span className="text-[11px] text-muted-foreground">{t("hostsDialog.variables.time_left")}</span>
-                                                                </div>
-                                                                <div className="flex items-center gap-1.5">
-                                                                    <code className="text-[11px] bg-muted/50 px-1.5 py-0.5 rounded-sm">{"{STATUS_TEXT}"}</code>
-                                                                    <span className="text-[11px] text-muted-foreground">{t("hostsDialog.variables.status_text")}</span>
-                                                                </div>
-                                                                <div className="flex items-center gap-1.5">
-                                                                    <code className="text-[11px] bg-muted/50 px-1.5 py-0.5 rounded-sm">{"{STATUS_EMOJI}"}</code>
-                                                                    <span className="text-[11px] text-muted-foreground">{t("hostsDialog.variables.status_emoji")}</span>
-                                                                </div>
-                                                                <div className="flex items-center gap-1.5">
-                                                                    <code className="text-[11px] bg-muted/50 px-1.5 py-0.5 rounded-sm">{"{PROTOCOL}"}</code>
-                                                                    <span className="text-[11px] text-muted-foreground">{t("hostsDialog.variables.protocol")}</span>
-                                                                </div>
-                                                                <div className="flex items-center gap-1.5">
-                                                                    <code className="text-[11px] bg-muted/50 px-1.5 py-0.5 rounded-sm">{"{TRANSPORT}"}</code>
-                                                                    <span className="text-[11px] text-muted-foreground">{t("hostsDialog.variables.transport")}</span>
-                                                                </div>
+                                                            <div className="flex items-center gap-3 w-full">
+                                                                <Checkbox
+                                                                    checked={field.value?.includes(option.value)}
+                                                                    className="h-4 w-4"
+                                                                />
+                                                                <span className="font-normal text-sm">{t(option.label)}</span>
                                                             </div>
-                                                        </div>
-                                                    </PopoverContent>
-                                                </Popover>
-                                            </div>
-                                            <FormControl>
-                                                <Input placeholder="example.com" {...field} />
-                                            </FormControl>
-                                            <FormMessage />
-                                        </FormItem>
-                                    )}
-                                />
-                            </div>
-                            <div className="flex-1">
-                                <FormField
-                                    control={form.control}
-                                    name="port"
-                                    render={({ field }) => (
-                                        <FormItem>
-                                            <div className="flex items-center gap-2">
-                                                <FormLabel>{t("hostsDialog.port")}</FormLabel>
-                                                <Popover>
-                                                    <PopoverTrigger asChild>
-                                                        <Button
-                                                            type="button"
-                                                            variant="ghost"
-                                                            size="icon"
-                                                            className="h-4 w-4 p-0 hover:bg-transparent"
-                                                        >
-                                                            <Info className="h-4 w-4 text-muted-foreground" />
-                                                        </Button>
-                                                    </PopoverTrigger>
-                                                    <PopoverContent className="w-[320px] p-3" side="right" align="start" sideOffset={5}>
-                                                        <p className="text-[11px] text-muted-foreground">{t("hostsDialog.port.info")}</p>
-                                                    </PopoverContent>
-                                                </Popover>
-                                            </div>
-                                            <FormControl>
-                                                <Input
-                                                    placeholder="443"
-                                                    type="number"
-                                                    {...field}
-                                                    onChange={(e) => {
-                                                        const val = e.target.value;
-                                                        field.onChange(val === "" ? "" : Number.parseInt(val, 10));
-                                                    }}
-                                                    value={field.value === undefined ? "" : field.value}
-                                                />
-                                            </FormControl>
-                                            <FormMessage />
-                                        </FormItem>
-                                    )}
-                                />
-                            </div>
-                        </div>
-
-                        <Accordion
-                            type="single"
-                            collapsible
-                            value={openSection}
-                            onValueChange={handleAccordionChange}
-                            className="w-full flex flex-col gap-y-6 mb-6 pt-6"
-                        >
-                            <AccordionItem className="border px-4 rounded-sm [&_[data-state=open]]:no-underline [&_[data-state=closed]]:no-underline" value="network">
-                                <AccordionTrigger>
-                                    <div className="flex items-center gap-2">
-                                        <GlobeLock className="h-4 w-4" />
-                                        <span>{t("hostsDialog.networkSettings")}</span>
-                                    </div>
-                                </AccordionTrigger>
-                                <AccordionContent className="px-2">
-                                    <div className="space-y-6">
-                                        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                            <FormField
-                                                control={form.control}
-                                                name="host"
-                                                render={({ field }) => (
-                                                    <FormItem>
-                                                        <div className="flex items-center gap-2">
-                                                            <FormLabel>{t("hostsDialog.host")}</FormLabel>
-                                                            <Popover>
-                                                                <PopoverTrigger asChild>
-                                                                    <Button
-                                                                        type="button"
-                                                                        variant="ghost"
-                                                                        size="icon"
-                                                                        className="h-4 w-4 p-0 hover:bg-transparent"
-                                                                    >
-                                                                        <Info className="h-4 w-4 text-muted-foreground" />
-                                                                    </Button>
-                                                                </PopoverTrigger>
-                                                                <PopoverContent className="w-[320px] p-3" side="right" align="start" sideOffset={5}>
-                                                                    <div className="space-y-1.5">
-                                                                        <p className="text-[11px] text-muted-foreground">{t("hostsDialog.host.info")}</p>
-                                                                        <p className="text-[11px] text-muted-foreground">{t("hostsDialog.host.multiHost")}</p>
-                                                                        <p className="text-[11px] text-muted-foreground">{t("hostsDialog.host.wildcard")}</p>
-                                                                    </div>
-                                                                </PopoverContent>
-                                                            </Popover>
-                                                        </div>
-                                                        <FormControl>
-                                                            <Input placeholder="Host (e.g. example.com)" {...field} />
-                                                        </FormControl>
-                                                        <FormMessage />
-                                                    </FormItem>
-                                                )}
-                                            />
-                                            <FormField
-                                                control={form.control}
-                                                name="path"
-                                                render={({ field }) => (
-                                                    <FormItem>
-                                                        <div className="flex items-center gap-2">
-                                                            <FormLabel>{t("hostsDialog.path")}</FormLabel>
-                                                            <Popover>
-                                                                <PopoverTrigger asChild>
-                                                                    <Button
-                                                                        type="button"
-                                                                        variant="ghost"
-                                                                        size="icon"
-                                                                        className="h-4 w-4 p-0 hover:bg-transparent"
-                                                                    >
-                                                                        <Info className="h-4 w-4 text-muted-foreground" />
-                                                                    </Button>
-                                                                </PopoverTrigger>
-                                                                <PopoverContent className="w-[320px] p-3" side="right" align="start" sideOffset={5}>
-                                                                    <p className="text-[11px] text-muted-foreground">{t("hostsDialog.path.info")}</p>
-                                                                </PopoverContent>
-                                                            </Popover>
-                                                        </div>
-                                                        <FormControl>
-                                                            <Input placeholder="Path (e.g. /xray)" {...field} />
-                                                        </FormControl>
-                                                        <FormMessage />
-                                                    </FormItem>
-                                                )}
-                                            />
-                                        </div>
-
-                                        <FormField
-                                            control={form.control}
-                                            name="random_user_agent"
-                                            render={({ field }) => (
-                                                <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
-                                                    <div className="space-y-0.5">
-                                                        <FormLabel className="text-base">
-                                                            {t("hostsDialog.randomUserAgent")}
-                                                        </FormLabel>
-                                                    </div>
-                                                    <FormControl>
-                                                        <Switch
-                                                            checked={field.value}
-                                                            onCheckedChange={field.onChange}
-                                                        />
-                                                    </FormControl>
-                                                </FormItem>
-                                            )}
-                                        />
-
-                                        <div className="space-y-2">
-                                            <div className="flex items-center justify-between">
-                                                <h4 className="text-sm font-medium">{t("hostsDialog.httpHeaders")}</h4>
+                                                        </SelectItem>
+                                                    ))}
+                                                </SelectContent>
+                                            </Select>
+                                            {field.value && field.value.length > 0 && (
                                                 <Button
                                                     type="button"
                                                     variant="outline"
-                                                    size="icon"
-                                                    className="h-6 w-6"
-                                                    onClick={() => {
-                                                        const currentHeaders = form.getValues("http_headers") || {};
-                                                        const newKey = `header_${Object.keys(currentHeaders).length}`;
-                                                        form.setValue("http_headers", {
-                                                            ...currentHeaders,
-                                                            [newKey]: ""
-                                                        }, {
-                                                            shouldDirty: true,
-                                                            shouldTouch: true
-                                                        });
-                                                    }}
-                                                    title={t("hostsDialog.addHeader")}
+                                                    size="sm"
+                                                    onClick={() => field.onChange([])}
+                                                    className="w-full"
                                                 >
-                                                    <Plus className="h-4 w-4" />
+                                                    {t("hostsDialog.clearAllStatuses")}
                                                 </Button>
+                                            )}
+                                        </div>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+
+                            <FormField
+                                control={form.control}
+                                name="remark"
+                                render={({ field }) => (
+                                    <FormItem>
+                                        <div className="flex items-center gap-2">
+                                            <FormLabel>{t("remark")}</FormLabel>
+                                            <Popover>
+                                                <PopoverTrigger asChild>
+                                                    <Button
+                                                        type="button"
+                                                        variant="ghost"
+                                                        size="icon"
+                                                        className="h-4 w-4 p-0 hover:bg-transparent"
+                                                    >
+                                                        <Info className="h-4 w-4 text-muted-foreground" />
+                                                    </Button>
+                                                </PopoverTrigger>
+                                                <PopoverContent
+                                                    className="w-[320px] p-3"
+                                                    side="right"
+                                                    align="start"
+                                                >
+                                                    <div className="space-y-1.5">
+                                                        <h4 className="font-medium text-[12px] mb-2">{t("hostsDialog.variables.title")}</h4>
+                                                        <div className="space-y-1">
+                                                            <div className="flex items-center gap-1.5">
+                                                                <code className="text-[11px] bg-muted/50 px-1.5 py-0.5 rounded-sm">{"{SERVER_IP}"}</code>
+                                                                <span className="text-[11px] text-muted-foreground">{t("hostsDialog.variables.server_ip")}</span>
+                                                            </div>
+                                                            <div className="flex items-center gap-1.5">
+                                                                <code className="text-[11px] bg-muted/50 px-1.5 py-0.5 rounded-sm">{"{SERVER_IPV6}"}</code>
+                                                                <span className="text-[11px] text-muted-foreground">{t("hostsDialog.variables.server_ipv6")}</span>
+                                                            </div>
+                                                            <div className="flex items-center gap-1.5">
+                                                                <code className="text-[11px] bg-muted/50 px-1.5 py-0.5 rounded-sm">{"{USERNAME}"}</code>
+                                                                <span className="text-[11px] text-muted-foreground">{t("hostsDialog.variables.username")}</span>
+                                                            </div>
+                                                            <div className="flex items-center gap-1.5">
+                                                                <code className="text-[11px] bg-muted/50 px-1.5 py-0.5 rounded-sm">{"{DATA_USAGE}"}</code>
+                                                                <span className="text-[11px] text-muted-foreground">{t("hostsDialog.variables.data_usage")}</span>
+                                                            </div>
+                                                            <div className="flex items-center gap-1.5">
+                                                                <code className="text-[11px] bg-muted/50 px-1.5 py-0.5 rounded-sm">{"{DATA_LEFT}"}</code>
+                                                                <span className="text-[11px] text-muted-foreground">{t("hostsDialog.variables.data_left")}</span>
+                                                            </div>
+                                                            <div className="flex items-center gap-1.5">
+                                                                <code className="text-[11px] bg-muted/50 px-1.5 py-0.5 rounded-sm">{"{DATA_LIMIT}"}</code>
+                                                                <span className="text-[11px] text-muted-foreground">{t("hostsDialog.variables.data_limit")}</span>
+                                                            </div>
+                                                            <div className="flex items-center gap-1.5">
+                                                                <code className="text-[11px] bg-muted/50 px-1.5 py-0.5 rounded-sm">{"{DAYS_LEFT}"}</code>
+                                                                <span className="text-[11px] text-muted-foreground">{t("hostsDialog.variables.days_left")}</span>
+                                                            </div>
+                                                            <div className="flex items-center gap-1.5">
+                                                                <code className="text-[11px] bg-muted/50 px-1.5 py-0.5 rounded-sm">{"{EXPIRE_DATE}"}</code>
+                                                                <span className="text-[11px] text-muted-foreground">{t("hostsDialog.variables.expire_date")}</span>
+                                                            </div>
+                                                            <div className="flex items-center gap-1.5">
+                                                                <code className="text-[11px] bg-muted/50 px-1.5 py-0.5 rounded-sm">{"{JALALI_EXPIRE_DATE}"}</code>
+                                                                <span className="text-[11px] text-muted-foreground">{t("hostsDialog.variables.jalali_expire_date")}</span>
+                                                            </div>
+                                                            <div className="flex items-center gap-1.5">
+                                                                <code className="text-[11px] bg-muted/50 px-1.5 py-0.5 rounded-sm">{"{TIME_LEFT}"}</code>
+                                                                <span className="text-[11px] text-muted-foreground">{t("hostsDialog.variables.time_left")}</span>
+                                                            </div>
+                                                            <div className="flex items-center gap-1.5">
+                                                                <code className="text-[11px] bg-muted/50 px-1.5 py-0.5 rounded-sm">{"{STATUS_TEXT}"}</code>
+                                                                <span className="text-[11px] text-muted-foreground">{t("hostsDialog.variables.status_text")}</span>
+                                                            </div>
+                                                            <div className="flex items-center gap-1.5">
+                                                                <code className="text-[11px] bg-muted/50 px-1.5 py-0.5 rounded-sm">{"{STATUS_EMOJI}"}</code>
+                                                                <span className="text-[11px] text-muted-foreground">{t("hostsDialog.variables.status_emoji")}</span>
+                                                            </div>
+                                                            <div className="flex items-center gap-1.5">
+                                                                <code className="text-[11px] bg-muted/50 px-1.5 py-0.5 rounded-sm">{"{PROTOCOL}"}</code>
+                                                                <span className="text-[11px] text-muted-foreground">{t("hostsDialog.variables.protocol")}</span>
+                                                            </div>
+                                                            <div className="flex items-center gap-1.5">
+                                                                <code className="text-[11px] bg-muted/50 px-1.5 py-0.5 rounded-sm">{"{TRANSPORT}"}</code>
+                                                                <span className="text-[11px] text-muted-foreground">{t("hostsDialog.variables.transport")}</span>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                </PopoverContent>
+                                            </Popover>
+                                        </div>
+                                        <FormControl>
+                                            <Input placeholder="Remark (e.g. Marzban-Host)" {...field} />
+                                        </FormControl>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+
+                            <div className="flex items-center gap-4 justify-between">
+                                <div className="flex-[2]">
+                                    <FormField
+                                        control={form.control}
+                                        name="address"
+                                        render={({ field }) => (
+                                            <FormItem>
+                                                <div className="flex items-center gap-2">
+
+                                                    <FormLabel>{t("hostsDialog.address")}</FormLabel>
+                                                    <Popover>
+                                                        <PopoverTrigger asChild>
+                                                            <Button
+                                                                type="button"
+                                                                variant="ghost"
+                                                                size="icon"
+                                                                className="h-4 w-4 p-0 hover:bg-transparent"
+                                                            >
+                                                                <Info className="h-4 w-4 text-muted-foreground" />
+                                                            </Button>
+                                                        </PopoverTrigger>
+                                                        <PopoverContent
+                                                            className="w-[320px] p-3"
+                                                            side="right"
+                                                            align="start"
+                                                            sideOffset={5}
+                                                        >
+                                                            <div className="space-y-1.5">
+                                                                <h4 className="font-medium text-[12px] mb-2">{t("hostsDialog.variables.title")}</h4>
+                                                                <div className="space-y-1">
+                                                                    <div className="flex items-center gap-1.5">
+                                                                        <code className="text-[11px] bg-muted/50 px-1.5 py-0.5 rounded-sm">{"{SERVER_IP}"}</code>
+                                                                        <span className="text-[11px] text-muted-foreground">{t("hostsDialog.variables.server_ip")}</span>
+                                                                    </div>
+                                                                    <div className="flex items-center gap-1.5">
+                                                                        <code className="text-[11px] bg-muted/50 px-1.5 py-0.5 rounded-sm">{"{SERVER_IPV6}"}</code>
+                                                                        <span className="text-[11px] text-muted-foreground">{t("hostsDialog.variables.server_ipv6")}</span>
+                                                                    </div>
+                                                                    <div className="flex items-center gap-1.5">
+                                                                        <code className="text-[11px] bg-muted/50 px-1.5 py-0.5 rounded-sm">{"{USERNAME}"}</code>
+                                                                        <span className="text-[11px] text-muted-foreground">{t("hostsDialog.variables.username")}</span>
+                                                                    </div>
+                                                                    <div className="flex items-center gap-1.5">
+                                                                        <code className="text-[11px] bg-muted/50 px-1.5 py-0.5 rounded-sm">{"{DATA_USAGE}"}</code>
+                                                                        <span className="text-[11px] text-muted-foreground">{t("hostsDialog.variables.data_usage")}</span>
+                                                                    </div>
+                                                                    <div className="flex items-center gap-1.5">
+                                                                        <code className="text-[11px] bg-muted/50 px-1.5 py-0.5 rounded-sm">{"{DATA_LEFT}"}</code>
+                                                                        <span className="text-[11px] text-muted-foreground">{t("hostsDialog.variables.data_left")}</span>
+                                                                    </div>
+                                                                    <div className="flex items-center gap-1.5">
+                                                                        <code className="text-[11px] bg-muted/50 px-1.5 py-0.5 rounded-sm">{"{DATA_LIMIT}"}</code>
+                                                                        <span className="text-[11px] text-muted-foreground">{t("hostsDialog.variables.data_limit")}</span>
+                                                                    </div>
+                                                                    <div className="flex items-center gap-1.5">
+                                                                        <code className="text-[11px] bg-muted/50 px-1.5 py-0.5 rounded-sm">{"{DAYS_LEFT}"}</code>
+                                                                        <span className="text-[11px] text-muted-foreground">{t("hostsDialog.variables.days_left")}</span>
+                                                                    </div>
+                                                                    <div className="flex items-center gap-1.5">
+                                                                        <code className="text-[11px] bg-muted/50 px-1.5 py-0.5 rounded-sm">{"{EXPIRE_DATE}"}</code>
+                                                                        <span className="text-[11px] text-muted-foreground">{t("hostsDialog.variables.expire_date")}</span>
+                                                                    </div>
+                                                                    <div className="flex items-center gap-1.5">
+                                                                        <code className="text-[11px] bg-muted/50 px-1.5 py-0.5 rounded-sm">{"{JALALI_EXPIRE_DATE}"}</code>
+                                                                        <span className="text-[11px] text-muted-foreground">{t("hostsDialog.variables.jalali_expire_date")}</span>
+                                                                    </div>
+                                                                    <div className="flex items-center gap-1.5">
+                                                                        <code className="text-[11px] bg-muted/50 px-1.5 py-0.5 rounded-sm">{"{TIME_LEFT}"}</code>
+                                                                        <span className="text-[11px] text-muted-foreground">{t("hostsDialog.variables.time_left")}</span>
+                                                                    </div>
+                                                                    <div className="flex items-center gap-1.5">
+                                                                        <code className="text-[11px] bg-muted/50 px-1.5 py-0.5 rounded-sm">{"{STATUS_TEXT}"}</code>
+                                                                        <span className="text-[11px] text-muted-foreground">{t("hostsDialog.variables.status_text")}</span>
+                                                                    </div>
+                                                                    <div className="flex items-center gap-1.5">
+                                                                        <code className="text-[11px] bg-muted/50 px-1.5 py-0.5 rounded-sm">{"{STATUS_EMOJI}"}</code>
+                                                                        <span className="text-[11px] text-muted-foreground">{t("hostsDialog.variables.status_emoji")}</span>
+                                                                    </div>
+                                                                    <div className="flex items-center gap-1.5">
+                                                                        <code className="text-[11px] bg-muted/50 px-1.5 py-0.5 rounded-sm">{"{PROTOCOL}"}</code>
+                                                                        <span className="text-[11px] text-muted-foreground">{t("hostsDialog.variables.protocol")}</span>
+                                                                    </div>
+                                                                    <div className="flex items-center gap-1.5">
+                                                                        <code className="text-[11px] bg-muted/50 px-1.5 py-0.5 rounded-sm">{"{TRANSPORT}"}</code>
+                                                                        <span className="text-[11px] text-muted-foreground">{t("hostsDialog.variables.transport")}</span>
+                                                                    </div>
+                                                                </div>
+                                                            </div>
+                                                        </PopoverContent>
+                                                    </Popover>
+                                                </div>
+                                                <FormControl>
+                                                    <Input placeholder="example.com" {...field} />
+                                                </FormControl>
+                                                <FormMessage />
+                                            </FormItem>
+                                        )}
+                                    />
+                                </div>
+                                <div className="flex-1">
+                                    <FormField
+                                        control={form.control}
+                                        name="port"
+                                        render={({ field }) => (
+                                            <FormItem>
+                                                <div className="flex items-center gap-2">
+                                                    <FormLabel>{t("hostsDialog.port")}</FormLabel>
+                                                    <Popover>
+                                                        <PopoverTrigger asChild>
+                                                            <Button
+                                                                type="button"
+                                                                variant="ghost"
+                                                                size="icon"
+                                                                className="h-4 w-4 p-0 hover:bg-transparent"
+                                                            >
+                                                                <Info className="h-4 w-4 text-muted-foreground" />
+                                                            </Button>
+                                                        </PopoverTrigger>
+                                                        <PopoverContent className="w-[320px] p-3" side="right" align="start" sideOffset={5}>
+                                                            <p className="text-[11px] text-muted-foreground">{t("hostsDialog.port.info")}</p>
+                                                        </PopoverContent>
+                                                    </Popover>
+                                                </div>
+                                                <FormControl>
+                                                    <Input
+                                                        placeholder="443"
+                                                        type="number"
+                                                        {...field}
+                                                        onChange={(e) => {
+                                                            const val = e.target.value;
+                                                            field.onChange(val === "" ? "" : Number.parseInt(val, 10));
+                                                        }}
+                                                        value={field.value === undefined ? "" : field.value}
+                                                    />
+                                                </FormControl>
+                                                <FormMessage />
+                                            </FormItem>
+                                        )}
+                                    />
+                                </div>
+                            </div>
+
+                            <Accordion
+                                type="single"
+                                collapsible
+                                value={openSection}
+                                onValueChange={handleAccordionChange}
+                                className="w-full flex flex-col gap-y-6 mb-6 pt-6"
+                            >
+                                <AccordionItem className="border px-4 rounded-sm [&_[data-state=open]]:no-underline [&_[data-state=closed]]:no-underline" value="network">
+                                    <AccordionTrigger>
+                                        <div className="flex items-center gap-2">
+                                            <GlobeLock className="h-4 w-4" />
+                                            <span>{t("hostsDialog.networkSettings")}</span>
+                                        </div>
+                                    </AccordionTrigger>
+                                    <AccordionContent className="px-2">
+                                        <div className="space-y-6">
+                                            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                                <FormField
+                                                    control={form.control}
+                                                    name="host"
+                                                    render={({ field }) => (
+                                                        <FormItem>
+                                                            <div className="flex items-center gap-2">
+                                                                <FormLabel>{t("hostsDialog.host")}</FormLabel>
+                                                                <Popover>
+                                                                    <PopoverTrigger asChild>
+                                                                        <Button
+                                                                            type="button"
+                                                                            variant="ghost"
+                                                                            size="icon"
+                                                                            className="h-4 w-4 p-0 hover:bg-transparent"
+                                                                        >
+                                                                            <Info className="h-4 w-4 text-muted-foreground" />
+                                                                        </Button>
+                                                                    </PopoverTrigger>
+                                                                    <PopoverContent className="w-[320px] p-3" side="right" align="start" sideOffset={5}>
+                                                                        <div className="space-y-1.5">
+                                                                            <p className="text-[11px] text-muted-foreground">{t("hostsDialog.host.info")}</p>
+                                                                            <p className="text-[11px] text-muted-foreground">{t("hostsDialog.host.multiHost")}</p>
+                                                                            <p className="text-[11px] text-muted-foreground">{t("hostsDialog.host.wildcard")}</p>
+                                                                        </div>
+                                                                    </PopoverContent>
+                                                                </Popover>
+                                                            </div>
+                                                            <FormControl>
+                                                                <Input placeholder="Host (e.g. example.com)" {...field} />
+                                                            </FormControl>
+                                                            <FormMessage />
+                                                        </FormItem>
+                                                    )}
+                                                />
+                                                <FormField
+                                                    control={form.control}
+                                                    name="path"
+                                                    render={({ field }) => (
+                                                        <FormItem>
+                                                            <div className="flex items-center gap-2">
+                                                                <FormLabel>{t("hostsDialog.path")}</FormLabel>
+                                                                <Popover>
+                                                                    <PopoverTrigger asChild>
+                                                                        <Button
+                                                                            type="button"
+                                                                            variant="ghost"
+                                                                            size="icon"
+                                                                            className="h-4 w-4 p-0 hover:bg-transparent"
+                                                                        >
+                                                                            <Info className="h-4 w-4 text-muted-foreground" />
+                                                                        </Button>
+                                                                    </PopoverTrigger>
+                                                                    <PopoverContent className="w-[320px] p-3" side="right" align="start" sideOffset={5}>
+                                                                        <p className="text-[11px] text-muted-foreground">{t("hostsDialog.path.info")}</p>
+                                                                    </PopoverContent>
+                                                                </Popover>
+                                                            </div>
+                                                            <FormControl>
+                                                                <Input placeholder="Path (e.g. /xray)" {...field} />
+                                                            </FormControl>
+                                                            <FormMessage />
+                                                        </FormItem>
+                                                    )}
+                                                />
                                             </div>
+
+                                            <FormField
+                                                control={form.control}
+                                                name="random_user_agent"
+                                                render={({ field }) => (
+                                                    <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
+                                                        <div className="space-y-0.5">
+                                                            <FormLabel className="text-base">
+                                                                {t("hostsDialog.randomUserAgent")}
+                                                            </FormLabel>
+                                                        </div>
+                                                        <FormControl>
+                                                            <Switch
+                                                                checked={field.value}
+                                                                onCheckedChange={field.onChange}
+                                                            />
+                                                        </FormControl>
+                                                    </FormItem>
+                                                )}
+                                            />
+
                                             <div className="space-y-2">
-                                                {Object.entries(form.watch("http_headers") || {}).map(([key, value]) => (
-                                                    <div key={key} className="grid grid-cols-[1fr,1fr,auto] gap-2">
-                                                        <Input
-                                                            placeholder={t("hostsDialog.headersName")}
-                                                            defaultValue={key}
-                                                            onBlur={(e) => {
-                                                                if (e.target.value !== key) {
+                                                <div className="flex items-center justify-between">
+                                                    <h4 className="text-sm font-medium">{t("hostsDialog.httpHeaders")}</h4>
+                                                    <Button
+                                                        type="button"
+                                                        variant="outline"
+                                                        size="icon"
+                                                        className="h-6 w-6"
+                                                        onClick={() => {
+                                                            const currentHeaders = form.getValues("http_headers") || {};
+                                                            const newKey = `header_${Object.keys(currentHeaders).length}`;
+                                                            form.setValue("http_headers", {
+                                                                ...currentHeaders,
+                                                                [newKey]: ""
+                                                            }, {
+                                                                shouldDirty: true,
+                                                                shouldTouch: true
+                                                            });
+                                                        }}
+                                                        title={t("hostsDialog.addHeader")}
+                                                    >
+                                                        <Plus className="h-4 w-4" />
+                                                    </Button>
+                                                </div>
+                                                <div className="space-y-2">
+                                                    {Object.entries(form.watch("http_headers") || {}).map(([key, value]) => (
+                                                        <div key={key} className="grid grid-cols-[1fr,1fr,auto] gap-2">
+                                                            <Input
+                                                                placeholder={t("hostsDialog.headersName")}
+                                                                defaultValue={key}
+                                                                onBlur={(e) => {
+                                                                    if (e.target.value !== key) {
+                                                                        const currentHeaders = { ...form.getValues("http_headers") };
+                                                                        const oldValue = currentHeaders[key];
+                                                                        delete currentHeaders[key];
+                                                                        currentHeaders[e.target.value] = oldValue;
+                                                                        form.setValue("http_headers", currentHeaders, {
+                                                                            shouldDirty: true,
+                                                                            shouldTouch: true
+                                                                        });
+                                                                    }
+                                                                }}
+                                                            />
+                                                            <Input
+                                                                placeholder={t("hostsDialog.headersValue")}
+                                                                value={value}
+                                                                onChange={(e) => {
                                                                     const currentHeaders = { ...form.getValues("http_headers") };
-                                                                    const oldValue = currentHeaders[key];
-                                                                    delete currentHeaders[key];
-                                                                    currentHeaders[e.target.value] = oldValue;
+                                                                    currentHeaders[key] = e.target.value;
                                                                     form.setValue("http_headers", currentHeaders, {
                                                                         shouldDirty: true,
                                                                         shouldTouch: true
                                                                     });
-                                                                }
-                                                            }}
-                                                        />
-                                                        <Input
-                                                            placeholder={t("hostsDialog.headersValue")}
-                                                            value={value}
-                                                            onChange={(e) => {
-                                                                const currentHeaders = { ...form.getValues("http_headers") };
-                                                                currentHeaders[key] = e.target.value;
-                                                                form.setValue("http_headers", currentHeaders, {
-                                                                    shouldDirty: true,
-                                                                    shouldTouch: true
-                                                                });
-                                                            }}
-                                                        />
-                                                        <Button
-                                                            type="button"
-                                                            variant="ghost"
-                                                            size="icon"
-                                                            className="h-8 w-8 border-red-500"
-                                                            onClick={() => {
-                                                                const currentHeaders = { ...form.getValues("http_headers") };
-                                                                delete currentHeaders[key];
-                                                                form.setValue("http_headers", currentHeaders, {
-                                                                    shouldDirty: true,
-                                                                    shouldTouch: true
-                                                                });
-                                                            }}
-                                                            title={t("hostsDialog.removeHeader")}
-                                                        >
-                                                            <Trash2 className="h-4 w-4 text-red-500" />
-                                                        </Button>
-                                                    </div>
-                                                ))}
-                                            </div>
-                                        </div>
-                                    </div>
-                                </AccordionContent>
-                            </AccordionItem>
-
-                            <AccordionItem className="border px-4 rounded-sm [&_[data-state=open]]:no-underline [&_[data-state=closed]]:no-underline" value="security">
-                                <AccordionTrigger>
-                                    <div className="flex items-center gap-2">
-                                        <Lock className="h-4 w-4" />
-                                        <span>{t("hostsDialog.securitySettings")}</span>
-                                    </div>
-                                </AccordionTrigger>
-                                <AccordionContent className="px-2">
-                                    <div className="space-y-6">
-                                        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                            <FormField
-                                                control={form.control}
-                                                name="security"
-                                                render={({ field }) => (
-                                                    <FormItem>
-                                                        <div className="flex items-center gap-2">
-                                                            <FormLabel>{t("hostsDialog.security")}</FormLabel>
-                                                            <Popover>
-                                                                <PopoverTrigger asChild>
-                                                                    <Button
-                                                                        type="button"
-                                                                        variant="ghost"
-                                                                        size="icon"
-                                                                        className="h-4 w-4 p-0 hover:bg-transparent"
-                                                                    >
-                                                                        <Info className="h-4 w-4 text-muted-foreground" />
-                                                                    </Button>
-                                                                </PopoverTrigger>
-                                                                <PopoverContent className="w-[320px] p-3" side="right" align="start" sideOffset={5}>
-                                                                    <p className="text-[11px] text-muted-foreground">{t("hostsDialog.security.info")}</p>
-                                                                </PopoverContent>
-                                                            </Popover>
-                                                        </div>
-                                                        <Select onValueChange={field.onChange} value={field.value}>
-                                                            <FormControl>
-                                                                <SelectTrigger>
-                                                                    <SelectValue />
-                                                                </SelectTrigger>
-                                                            </FormControl>
-                                                            <SelectContent>
-                                                                <SelectItem value="none">None</SelectItem>
-                                                                <SelectItem value="tls">TLS</SelectItem>
-                                                                <SelectItem value="inbound_default">Inbound's default</SelectItem>
-                                                            </SelectContent>
-                                                        </Select>
-                                                        <FormMessage />
-                                                    </FormItem>
-                                                )}
-                                            />
-
-                                            <FormField
-                                                control={form.control}
-                                                name="sni"
-                                                render={({ field }) => (
-                                                    <FormItem>
-                                                        <div className="flex items-center gap-2">
-                                                            <FormLabel>{t("hostsDialog.sni")}</FormLabel>
-                                                            <Popover>
-                                                                <PopoverTrigger asChild>
-                                                                    <Button
-                                                                        type="button"
-                                                                        variant="ghost"
-                                                                        size="icon"
-                                                                        className="h-4 w-4 p-0 hover:bg-transparent"
-                                                                    >
-                                                                        <Info className="h-4 w-4 text-muted-foreground" />
-                                                                    </Button>
-                                                                </PopoverTrigger>
-                                                                <PopoverContent className="w-[320px] p-3" side="right" align="start" sideOffset={5}>
-                                                                    <p className="text-[11px] text-muted-foreground">{t("hostsDialog.sni.info")}</p>
-                                                                </PopoverContent>
-                                                            </Popover>
-                                                        </div>
-                                                        <FormControl>
-                                                            <Input placeholder={t("hostsDialog.sniPlaceholder")} {...field} />
-                                                        </FormControl>
-                                                        <FormMessage />
-                                                    </FormItem>
-                                                )}
-                                            />
-                                        </div>
-
-                                        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                            <FormField
-                                                control={form.control}
-                                                name="alpn"
-                                                render={({ field }) => (
-                                                    <FormItem>
-                                                        <FormLabel>{t("hostsDialog.alpn")}</FormLabel>
-                                                        <Select onValueChange={field.onChange} value={field.value}>
-                                                            <FormControl>
-                                                                <SelectTrigger>
-                                                                    <SelectValue placeholder={t("hostsDialog.alpn")} />
-                                                                </SelectTrigger>
-                                                            </FormControl>
-                                                            <SelectContent>
-                                                                <SelectItem value="default">{t("default")}</SelectItem>
-                                                                <SelectItem value="h3">h3</SelectItem>
-                                                                <SelectItem value="h2">h2</SelectItem>
-                                                                <SelectItem value="http/1.1">http/1.1</SelectItem>
-                                                                <SelectItem value="h3,h2,http/1.1">h3,h2,http/1.1</SelectItem>
-                                                                <SelectItem value="h3,h2">h3,h2</SelectItem>
-                                                                <SelectItem value="h2,http/1.1">h2,http/1.1</SelectItem>
-                                                            </SelectContent>
-                                                        </Select>
-                                                        <FormMessage />
-                                                    </FormItem>
-                                                )}
-                                            />
-
-                                            <FormField
-                                                control={form.control}
-                                                name="fingerprint"
-                                                render={({ field }) => (
-                                                    <FormItem>
-                                                        <FormLabel>{t("hostsDialog.fingerprint")}</FormLabel>
-                                                        <Select onValueChange={(value) => field.onChange(value === "default" ? "" : value)} value={field.value || "default"}>
-                                                            <FormControl>
-                                                                <SelectTrigger>
-                                                                    <SelectValue placeholder={t("hostsDialog.fingerprint")} />
-                                                                </SelectTrigger>
-                                                            </FormControl>
-                                                            <SelectContent>
-                                                                <SelectItem value="default">{t("default")}</SelectItem>
-                                                                <SelectItem value="chrome">{t("chrome")}</SelectItem>
-                                                                <SelectItem value="firefox">{t("firefox")}</SelectItem>
-                                                                <SelectItem value="safari">{t("safari")}</SelectItem>
-                                                                <SelectItem value="ios">{t("ios")}</SelectItem>
-                                                                <SelectItem value="android">{t("android")}</SelectItem>
-                                                                <SelectItem value="edge">{t("edge")}</SelectItem>
-                                                                <SelectItem value="360">{t("360")}</SelectItem>
-                                                                <SelectItem value="qq">{t("qq")}</SelectItem>
-                                                                <SelectItem value="random">{t("random")}</SelectItem>
-                                                                <SelectItem value="randomized">{t("randomized")}</SelectItem>
-                                                            </SelectContent>
-                                                        </Select>
-                                                        <FormMessage />
-                                                    </FormItem>
-                                                )}
-                                            />
-                                        </div>
-
-                                        <FormField
-                                            control={form.control}
-                                            name="allowinsecure"
-                                            render={({ field }) => (
-                                                <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
-                                                    <div className="space-y-0.5">
-                                                        <FormLabel className="text-base">
-                                                            {t("hostsDialog.allowInsecure")}
-                                                        </FormLabel>
-                                                    </div>
-                                                    <FormControl>
-                                                        <Switch
-                                                            checked={field.value}
-                                                            onCheckedChange={field.onChange}
-                                                        />
-                                                    </FormControl>
-                                                </FormItem>
-                                            )}
-                                        />
-
-                                        <FormField
-                                            control={form.control}
-                                            name="use_sni_as_host"
-                                            render={({ field }) => (
-                                                <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
-                                                    <div className="space-y-0.5">
-                                                        <FormLabel className="text-base">
-                                                            {t("hostsDialog.useSniAsHost")}
-                                                        </FormLabel>
-                                                    </div>
-                                                    <FormControl>
-                                                        <Switch
-                                                            checked={field.value}
-                                                            onCheckedChange={field.onChange}
-                                                        />
-                                                    </FormControl>
-                                                </FormItem>
-                                            )}
-                                        />
-                                    </div>
-                                </AccordionContent>
-                            </AccordionItem>
-
-                            <AccordionItem className="border px-4 rounded-sm [&_[data-state=open]]:no-underline [&_[data-state=closed]]:no-underline" value="camouflag">
-                                <AccordionTrigger>
-                                    <div className="flex items-center gap-2">
-                                        <ChevronsLeftRightEllipsis className="h-4 w-4" />
-                                        <span>{t("hostsDialog.camouflagSettings")}</span>
-                                    </div>
-                                </AccordionTrigger>
-                                <AccordionContent className="px-2">
-                                    <div className="space-y-6">
-                                        {/* Fragment Settings */}
-                                        <div className="space-y-4">
-                                            <div className="flex items-center justify-between">
-                                                <h4 className="text-sm font-medium flex items-center gap-2">
-                                                    {t("hostsDialog.fragment.title")}
-                                                    <Popover>
-                                                        <PopoverTrigger asChild>
+                                                                }}
+                                                            />
                                                             <Button
                                                                 type="button"
                                                                 variant="ghost"
                                                                 size="icon"
-                                                                className="h-4 w-4 p-0 hover:bg-transparent"
-                                                            >
-                                                                <Info className="h-4 w-4 text-muted-foreground" />
-                                                            </Button>
-                                                        </PopoverTrigger>
-                                                        <PopoverContent className="w-[320px] p-3" side="right" align="start" sideOffset={5}>
-                                                            <div className="space-y-1.5">
-                                                                <p className="text-[11px] text-muted-foreground">{t("hostsDialog.fragment.info")}</p>
-                                                                <p className="text-[11px] text-muted-foreground">{t("hostsDialog.fragment.info.attention")}</p>
-                                                                <p className="text-[11px] text-muted-foreground">{t("hostsDialog.fragment.info.examples")}</p>
-                                                                <p className="text-[11px] overflow-hidden text-muted-foreground">
-                                                                    100-200,10-20,tlshello
-                                                                    100-200,10-20,1-3
-                                                                </p>
-                                                            </div>
-                                                        </PopoverContent>
-                                                    </Popover>
-                                                </h4>
-                                            </div>
-                                            <div className="grid grid-cols-3 gap-4">
-                                                <FormField
-                                                    control={form.control}
-                                                    name="fragment_settings.xray.packets"
-                                                    render={({ field }) => (
-                                                        <FormItem>
-                                                            <FormLabel>{t("hostsDialog.fragment.packets")}</FormLabel>
-                                                            <FormControl>
-                                                                <Input
-                                                                    placeholder={t("hostsDialog.fragment.packetsPlaceholder")}
-                                                                    {...field}
-                                                                    value={field.value || ""}
-                                                                />
-                                                            </FormControl>
-                                                            <FormMessage />
-                                                        </FormItem>
-                                                    )}
-                                                />
-                                                <FormField
-                                                    control={form.control}
-                                                    name="fragment_settings.xray.length"
-                                                    render={({ field }) => (
-                                                        <FormItem>
-                                                            <FormLabel>{t("hostsDialog.fragment.length")}</FormLabel>
-                                                            <FormControl>
-                                                                <Input
-                                                                    placeholder={t("hostsDialog.fragment.lengthPlaceholder")}
-                                                                    {...field}
-                                                                    value={field.value || ""}
-                                                                />
-                                                            </FormControl>
-                                                            <FormMessage />
-                                                        </FormItem>
-                                                    )}
-                                                />
-                                                <FormField
-                                                    control={form.control}
-                                                    name="fragment_settings.xray.interval"
-                                                    render={({ field }) => (
-                                                        <FormItem>
-                                                            <FormLabel>{t("hostsDialog.fragment.interval")}</FormLabel>
-                                                            <FormControl>
-                                                                <Input
-                                                                    placeholder={t("hostsDialog.fragment.intervalPlaceholder")}
-                                                                    {...field}
-                                                                    value={field.value || ""}
-                                                                />
-                                                            </FormControl>
-                                                            <FormMessage />
-                                                        </FormItem>
-                                                    )}
-                                                />
-                                            </div>
-                                        </div>
-
-                                        {/* Noise Settings */}
-                                        <div className="space-y-4">
-                                            <div className="flex items-center justify-between">
-                                                <div className="flex items-center gap-2">
-                                                    <h4 className="text-sm font-medium">{t("hostsDialog.noise.title")}</h4>
-                                                    <Popover>
-                                                        <PopoverTrigger asChild>
-                                                            <Button
-                                                                type="button"
-                                                                variant="ghost"
-                                                                size="icon"
-                                                                className="h-4 w-4 p-0 hover:bg-transparent"
-                                                            >
-                                                                <Info className="h-4 w-4 text-muted-foreground" />
-                                                            </Button>
-                                                        </PopoverTrigger>
-                                                        <PopoverContent className="w-[320px] p-3" side="right" align="start" sideOffset={5}>
-                                                            <div className="space-y-1.5">
-                                                                <p className="text-[11px] text-muted-foreground">{t("hostsDialog.noise.info")}</p>
-                                                                <p className="text-[11px] text-muted-foreground">{t("hostsDialog.noise.info.attention")}</p>
-                                                                <p className="text-[11px] text-muted-foreground">{t("hostsDialog.noise.info.examples")}</p>
-                                                                <p className="text-[11px] overflow-hidden text-muted-foreground">
-                                                                    rand:10-20,10-20
-                                                                    rand:10-20,10-20
-                                                                    &base64:7nQBAAABAAAAAAAABnQtcmluZwZtc2VkZ2UDbmV0AAABAAE=,10-25</p>
-                                                            </div>
-                                                        </PopoverContent>
-                                                    </Popover>
-                                                </div>
-                                                <Button
-                                                    type="button"
-                                                    variant="outline"
-                                                    size="icon"
-                                                    className="h-6 w-6"
-                                                    onClick={() => {
-                                                        const currentNoiseSettings = form.getValues("noise_settings.xray") || [];
-                                                        form.setValue("noise_settings.xray", [...currentNoiseSettings, { type: "", packet: "", delay: "" }], {
-                                                            shouldDirty: true,
-                                                            shouldTouch: true
-                                                        });
-                                                    }}
-                                                    title={t("hostsDialog.noise.addNoise")}
-                                                >
-                                                    <Plus className="h-4 w-4" />
-                                                </Button>
-                                            </div>
-                                            <div className="space-y-2">
-                                                {(form.watch("noise_settings.xray") || []).map((_, index) => (
-                                                    <div key={index} className="flex items-center justify-between gap-2">
-                                                        <div className="flex items-center gap-2">
-                                                            <Select
-                                                                value={form.watch(`noise_settings.xray.${index}.type`) || ""}
-                                                                onValueChange={(value) => {
-                                                                    form.setValue(`noise_settings.xray.${index}.type`, value, {
+                                                                className="h-8 w-8 border-red-500"
+                                                                onClick={() => {
+                                                                    const currentHeaders = { ...form.getValues("http_headers") };
+                                                                    delete currentHeaders[key];
+                                                                    form.setValue("http_headers", currentHeaders, {
                                                                         shouldDirty: true,
                                                                         shouldTouch: true
                                                                     });
                                                                 }}
+                                                                title={t("hostsDialog.removeHeader")}
                                                             >
-                                                                <SelectTrigger className="w-[120px]">
-                                                                    <SelectValue placeholder="Type" />
-                                                                </SelectTrigger>
+                                                                <Trash2 className="h-4 w-4 text-red-500" />
+                                                            </Button>
+                                                        </div>
+                                                    ))}
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </AccordionContent>
+                                </AccordionItem>
+
+                                <AccordionItem className="border px-4 rounded-sm [&_[data-state=open]]:no-underline [&_[data-state=closed]]:no-underline" value="security">
+                                    <AccordionTrigger>
+                                        <div className="flex items-center gap-2">
+                                            <Lock className="h-4 w-4" />
+                                            <span>{t("hostsDialog.securitySettings")}</span>
+                                        </div>
+                                    </AccordionTrigger>
+                                    <AccordionContent className="px-2">
+                                        <div className="space-y-6">
+                                            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                                <FormField
+                                                    control={form.control}
+                                                    name="security"
+                                                    render={({ field }) => (
+                                                        <FormItem>
+                                                            <div className="flex items-center gap-2">
+                                                                <FormLabel>{t("hostsDialog.security")}</FormLabel>
+                                                                <Popover>
+                                                                    <PopoverTrigger asChild>
+                                                                        <Button
+                                                                            type="button"
+                                                                            variant="ghost"
+                                                                            size="icon"
+                                                                            className="h-4 w-4 p-0 hover:bg-transparent"
+                                                                        >
+                                                                            <Info className="h-4 w-4 text-muted-foreground" />
+                                                                        </Button>
+                                                                    </PopoverTrigger>
+                                                                    <PopoverContent className="w-[320px] p-3" side="right" align="start" sideOffset={5}>
+                                                                        <p className="text-[11px] text-muted-foreground">{t("hostsDialog.security.info")}</p>
+                                                                    </PopoverContent>
+                                                                </Popover>
+                                                            </div>
+                                                            <Select onValueChange={field.onChange} value={field.value}>
+                                                                <FormControl>
+                                                                    <SelectTrigger>
+                                                                        <SelectValue />
+                                                                    </SelectTrigger>
+                                                                </FormControl>
                                                                 <SelectContent>
-                                                                    <SelectItem value="rand">rand</SelectItem>
-                                                                    <SelectItem value="str">str</SelectItem>
-                                                                    <SelectItem value="base64">base64</SelectItem>
-                                                                    <SelectItem value="hex">hex</SelectItem>
+                                                                    <SelectItem value="none">None</SelectItem>
+                                                                    <SelectItem value="tls">TLS</SelectItem>
+                                                                    <SelectItem value="inbound_default">Inbound's default</SelectItem>
                                                                 </SelectContent>
                                                             </Select>
-                                                            <Input
-                                                                placeholder={t("hostsDialog.noise.packetPlaceholder")}
-                                                                value={form.watch(`noise_settings.xray.${index}.packet`) || ""}
-                                                                onChange={(e) => {
-                                                                    form.setValue(`noise_settings.xray.${index}.packet`, e.target.value, {
-                                                                        shouldDirty: true,
-                                                                        shouldTouch: true
-                                                                    });
-                                                                }}
-                                                            />
-                                                            <Input
-                                                                placeholder={t("hostsDialog.noise.delayPlaceholder")}
-                                                                value={form.watch(`noise_settings.xray.${index}.delay`) || ""}
-                                                                onChange={(e) => {
-                                                                    form.setValue(`noise_settings.xray.${index}.delay`, e.target.value, {
-                                                                        shouldDirty: true,
-                                                                        shouldTouch: true
-                                                                    });
-                                                                }}
-                                                            />
-                                                        </div>
-                                                        <Button
-                                                            type="button"
-                                                            variant="ghost"
-                                                            size="icon"
-                                                            className="h-8 w-8 border-red-500"
-                                                            onClick={() => {
-                                                                const currentNoiseSettings = [...(form.getValues("noise_settings.xray") || [])];
-                                                                currentNoiseSettings.splice(index, 1);
-                                                                form.setValue("noise_settings.xray", currentNoiseSettings, {
-                                                                    shouldDirty: true,
-                                                                    shouldTouch: true
-                                                                });
-                                                            }}
-                                                            title={t("hostsDialog.noise.removeNoise")}
-                                                        >
-                                                            <Trash2 className="h-4 w-4 text-red-500" />
-                                                        </Button>
-                                                    </div>
-                                                ))}
+                                                            <FormMessage />
+                                                        </FormItem>
+                                                    )}
+                                                />
+
+                                                <FormField
+                                                    control={form.control}
+                                                    name="sni"
+                                                    render={({ field }) => (
+                                                        <FormItem>
+                                                            <div className="flex items-center gap-2">
+                                                                <FormLabel>{t("hostsDialog.sni")}</FormLabel>
+                                                                <Popover>
+                                                                    <PopoverTrigger asChild>
+                                                                        <Button
+                                                                            type="button"
+                                                                            variant="ghost"
+                                                                            size="icon"
+                                                                            className="h-4 w-4 p-0 hover:bg-transparent"
+                                                                        >
+                                                                            <Info className="h-4 w-4 text-muted-foreground" />
+                                                                        </Button>
+                                                                    </PopoverTrigger>
+                                                                    <PopoverContent className="w-[320px] p-3" side="right" align="start" sideOffset={5}>
+                                                                        <p className="text-[11px] text-muted-foreground">{t("hostsDialog.sni.info")}</p>
+                                                                    </PopoverContent>
+                                                                </Popover>
+                                                            </div>
+                                                            <FormControl>
+                                                                <Input placeholder={t("hostsDialog.sniPlaceholder")} {...field} />
+                                                            </FormControl>
+                                                            <FormMessage />
+                                                        </FormItem>
+                                                    )}
+                                                />
                                             </div>
+
+                                            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                                <FormField
+                                                    control={form.control}
+                                                    name="alpn"
+                                                    render={({ field }) => (
+                                                        <FormItem>
+                                                            <FormLabel>{t("hostsDialog.alpn")}</FormLabel>
+                                                            <Select onValueChange={field.onChange} value={field.value}>
+                                                                <FormControl>
+                                                                    <SelectTrigger>
+                                                                        <SelectValue placeholder={t("hostsDialog.alpn")} />
+                                                                    </SelectTrigger>
+                                                                </FormControl>
+                                                                <SelectContent>
+                                                                    <SelectItem value="default">{t("default")}</SelectItem>
+                                                                    <SelectItem value="h3">h3</SelectItem>
+                                                                    <SelectItem value="h2">h2</SelectItem>
+                                                                    <SelectItem value="http/1.1">http/1.1</SelectItem>
+                                                                    <SelectItem value="h3,h2,http/1.1">h3,h2,http/1.1</SelectItem>
+                                                                    <SelectItem value="h3,h2">h3,h2</SelectItem>
+                                                                    <SelectItem value="h2,http/1.1">h2,http/1.1</SelectItem>
+                                                                </SelectContent>
+                                                            </Select>
+                                                            <FormMessage />
+                                                        </FormItem>
+                                                    )}
+                                                />
+
+                                                <FormField
+                                                    control={form.control}
+                                                    name="fingerprint"
+                                                    render={({ field }) => (
+                                                        <FormItem>
+                                                            <FormLabel>{t("hostsDialog.fingerprint")}</FormLabel>
+                                                            <Select onValueChange={(value) => field.onChange(value === "default" ? "" : value)} value={field.value || "default"}>
+                                                                <FormControl>
+                                                                    <SelectTrigger>
+                                                                        <SelectValue placeholder={t("hostsDialog.fingerprint")} />
+                                                                    </SelectTrigger>
+                                                                </FormControl>
+                                                                <SelectContent>
+                                                                    <SelectItem value="default">{t("default")}</SelectItem>
+                                                                    <SelectItem value="chrome">{t("chrome")}</SelectItem>
+                                                                    <SelectItem value="firefox">{t("firefox")}</SelectItem>
+                                                                    <SelectItem value="safari">{t("safari")}</SelectItem>
+                                                                    <SelectItem value="ios">{t("ios")}</SelectItem>
+                                                                    <SelectItem value="android">{t("android")}</SelectItem>
+                                                                    <SelectItem value="edge">{t("edge")}</SelectItem>
+                                                                    <SelectItem value="360">{t("360")}</SelectItem>
+                                                                    <SelectItem value="qq">{t("qq")}</SelectItem>
+                                                                    <SelectItem value="random">{t("random")}</SelectItem>
+                                                                    <SelectItem value="randomized">{t("randomized")}</SelectItem>
+                                                                </SelectContent>
+                                                            </Select>
+                                                            <FormMessage />
+                                                        </FormItem>
+                                                    )}
+                                                />
+                                            </div>
+
+                                            <FormField
+                                                control={form.control}
+                                                name="allowinsecure"
+                                                render={({ field }) => (
+                                                    <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
+                                                        <div className="space-y-0.5">
+                                                            <FormLabel className="text-base">
+                                                                {t("hostsDialog.allowInsecure")}
+                                                            </FormLabel>
+                                                        </div>
+                                                        <FormControl>
+                                                            <Switch
+                                                                checked={field.value}
+                                                                onCheckedChange={field.onChange}
+                                                            />
+                                                        </FormControl>
+                                                    </FormItem>
+                                                )}
+                                            />
+
+                                            <FormField
+                                                control={form.control}
+                                                name="use_sni_as_host"
+                                                render={({ field }) => (
+                                                    <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
+                                                        <div className="space-y-0.5">
+                                                            <FormLabel className="text-base">
+                                                                {t("hostsDialog.useSniAsHost")}
+                                                            </FormLabel>
+                                                        </div>
+                                                        <FormControl>
+                                                            <Switch
+                                                                checked={field.value}
+                                                                onCheckedChange={field.onChange}
+                                                            />
+                                                        </FormControl>
+                                                    </FormItem>
+                                                )}
+                                            />
                                         </div>
-                                    </div>
-                                </AccordionContent>
-                            </AccordionItem>
+                                    </AccordionContent>
+                                </AccordionItem>
 
-                            <AccordionItem className="border px-4 rounded-sm [&_[data-state=open]]:no-underline [&_[data-state=closed]]:no-underline" value="transport">
-                                <AccordionTrigger>
-                                    <div className="flex items-center gap-2">
-                                        <Network className="h-4 w-4" />
-                                        <span>{t("hostsDialog.transportSettingsAccordion")}</span>
-                                    </div>
-                                </AccordionTrigger>
-                                <AccordionContent>
-                                    <div className="space-y-4">
-                                        <Tabs defaultValue="xhttp" className="w-full">
-                                            <TabsList className="grid grid-cols-5 mb-4 gap-4 px-1 min-w-full overflow-x-auto">
-                                                <TabsTrigger className="px-2" value="xhttp">XHTTP</TabsTrigger>
-                                                <TabsTrigger className="px-2" value="grpc">gRPC</TabsTrigger>
-                                                <TabsTrigger className="px-2" value="kcp">KCP</TabsTrigger>
-                                                <TabsTrigger className="px-2" value="tcp">TCP</TabsTrigger>
-                                                <TabsTrigger className="px-2" value="websocket">WebSocket</TabsTrigger>
-                                            </TabsList>
-
-                                            {/* XHTTP Settings */}
-                                            <TabsContent dir={dir} value="xhttp" className="space-y-4 p-2">
-                                                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                <AccordionItem className="border px-4 rounded-sm [&_[data-state=open]]:no-underline [&_[data-state=closed]]:no-underline" value="camouflag">
+                                    <AccordionTrigger>
+                                        <div className="flex items-center gap-2">
+                                            <ChevronsLeftRightEllipsis className="h-4 w-4" />
+                                            <span>{t("hostsDialog.camouflagSettings")}</span>
+                                        </div>
+                                    </AccordionTrigger>
+                                    <AccordionContent className="px-2">
+                                        <div className="space-y-6">
+                                            {/* Fragment Settings */}
+                                            <div className="space-y-4">
+                                                <div className="flex items-center justify-between">
+                                                    <h4 className="text-sm font-medium flex items-center gap-2">
+                                                        {t("hostsDialog.fragment.title")}
+                                                        <Popover>
+                                                            <PopoverTrigger asChild>
+                                                                <Button
+                                                                    type="button"
+                                                                    variant="ghost"
+                                                                    size="icon"
+                                                                    className="h-4 w-4 p-0 hover:bg-transparent"
+                                                                >
+                                                                    <Info className="h-4 w-4 text-muted-foreground" />
+                                                                </Button>
+                                                            </PopoverTrigger>
+                                                            <PopoverContent className="w-[320px] p-3" side="right" align="start" sideOffset={5}>
+                                                                <div className="space-y-1.5">
+                                                                    <p className="text-[11px] text-muted-foreground">{t("hostsDialog.fragment.info")}</p>
+                                                                    <p className="text-[11px] text-muted-foreground">{t("hostsDialog.fragment.info.attention")}</p>
+                                                                    <p className="text-[11px] text-muted-foreground">{t("hostsDialog.fragment.info.examples")}</p>
+                                                                    <p className="text-[11px] overflow-hidden text-muted-foreground">
+                                                                        100-200,10-20,tlshello
+                                                                        100-200,10-20,1-3
+                                                                    </p>
+                                                                </div>
+                                                            </PopoverContent>
+                                                        </Popover>
+                                                    </h4>
+                                                </div>
+                                                <div className="grid grid-cols-3 gap-4">
                                                     <FormField
                                                         control={form.control}
-                                                        name="transport_settings.xhttp_settings.mode"
+                                                        name="fragment_settings.xray.packets"
                                                         render={({ field }) => (
                                                             <FormItem>
-                                                                <FormLabel>{t("hostsDialog.xhttp.mode")}</FormLabel>
-                                                                <Select onValueChange={field.onChange} value={field.value}>
-                                                                    <FormControl>
-                                                                        <SelectTrigger>
-                                                                            <SelectValue />
-                                                                        </SelectTrigger>
-                                                                    </FormControl>
+                                                                <FormLabel>{t("hostsDialog.fragment.packets")}</FormLabel>
+                                                                <FormControl>
+                                                                    <Input
+                                                                        placeholder={t("hostsDialog.fragment.packetsPlaceholder")}
+                                                                        {...field}
+                                                                        value={field.value || ""}
+                                                                    />
+                                                                </FormControl>
+                                                                <FormMessage />
+                                                            </FormItem>
+                                                        )}
+                                                    />
+                                                    <FormField
+                                                        control={form.control}
+                                                        name="fragment_settings.xray.length"
+                                                        render={({ field }) => (
+                                                            <FormItem>
+                                                                <FormLabel>{t("hostsDialog.fragment.length")}</FormLabel>
+                                                                <FormControl>
+                                                                    <Input
+                                                                        placeholder={t("hostsDialog.fragment.lengthPlaceholder")}
+                                                                        {...field}
+                                                                        value={field.value || ""}
+                                                                    />
+                                                                </FormControl>
+                                                                <FormMessage />
+                                                            </FormItem>
+                                                        )}
+                                                    />
+                                                    <FormField
+                                                        control={form.control}
+                                                        name="fragment_settings.xray.interval"
+                                                        render={({ field }) => (
+                                                            <FormItem>
+                                                                <FormLabel>{t("hostsDialog.fragment.interval")}</FormLabel>
+                                                                <FormControl>
+                                                                    <Input
+                                                                        placeholder={t("hostsDialog.fragment.intervalPlaceholder")}
+                                                                        {...field}
+                                                                        value={field.value || ""}
+                                                                    />
+                                                                </FormControl>
+                                                                <FormMessage />
+                                                            </FormItem>
+                                                        )}
+                                                    />
+                                                </div>
+                                            </div>
+
+                                            {/* Noise Settings */}
+                                            <div className="space-y-4">
+                                                <div className="flex items-center justify-between">
+                                                    <div className="flex items-center gap-2">
+                                                        <h4 className="text-sm font-medium">{t("hostsDialog.noise.title")}</h4>
+                                                        <Popover>
+                                                            <PopoverTrigger asChild>
+                                                                <Button
+                                                                    type="button"
+                                                                    variant="ghost"
+                                                                    size="icon"
+                                                                    className="h-4 w-4 p-0 hover:bg-transparent"
+                                                                >
+                                                                    <Info className="h-4 w-4 text-muted-foreground" />
+                                                                </Button>
+                                                            </PopoverTrigger>
+                                                            <PopoverContent className="w-[320px] p-3" side="right" align="start" sideOffset={5}>
+                                                                <div className="space-y-1.5">
+                                                                    <p className="text-[11px] text-muted-foreground">{t("hostsDialog.noise.info")}</p>
+                                                                    <p className="text-[11px] text-muted-foreground">{t("hostsDialog.noise.info.attention")}</p>
+                                                                    <p className="text-[11px] text-muted-foreground">{t("hostsDialog.noise.info.examples")}</p>
+                                                                    <p className="text-[11px] overflow-hidden text-muted-foreground">
+                                                                        rand:10-20,10-20
+                                                                        rand:10-20,10-20
+                                                                        &base64:7nQBAAABAAAAAAAABnQtcmluZwZtc2VkZ2UDbmV0AAABAAE=,10-25</p>
+                                                                </div>
+                                                            </PopoverContent>
+                                                        </Popover>
+                                                    </div>
+                                                    <Button
+                                                        type="button"
+                                                        variant="outline"
+                                                        size="icon"
+                                                        className="h-6 w-6"
+                                                        onClick={() => {
+                                                            const currentNoiseSettings = form.getValues("noise_settings.xray") || [];
+                                                            form.setValue("noise_settings.xray", [...currentNoiseSettings, { type: "", packet: "", delay: "" }], {
+                                                                shouldDirty: true,
+                                                                shouldTouch: true
+                                                            });
+                                                        }}
+                                                        title={t("hostsDialog.noise.addNoise")}
+                                                    >
+                                                        <Plus className="h-4 w-4" />
+                                                    </Button>
+                                                </div>
+                                                <div className="space-y-2">
+                                                    {(form.watch("noise_settings.xray") || []).map((_, index) => (
+                                                        <div key={index} className="flex items-center justify-between gap-2">
+                                                            <div className="flex items-center gap-2">
+                                                                <Select
+                                                                    value={form.watch(`noise_settings.xray.${index}.type`) || ""}
+                                                                    onValueChange={(value) => {
+                                                                        form.setValue(`noise_settings.xray.${index}.type`, value, {
+                                                                            shouldDirty: true,
+                                                                            shouldTouch: true
+                                                                        });
+                                                                    }}
+                                                                >
+                                                                    <SelectTrigger className="w-[120px]">
+                                                                        <SelectValue placeholder="Type" />
+                                                                    </SelectTrigger>
                                                                     <SelectContent>
-                                                                        <SelectItem value="auto">Auto</SelectItem>
-                                                                        <SelectItem value="packet-up">Packet Up</SelectItem>
-                                                                        <SelectItem value="stream-up">Stream Up</SelectItem>
-                                                                        <SelectItem value="stream-one">Stream One</SelectItem>
+                                                                        <SelectItem value="rand">rand</SelectItem>
+                                                                        <SelectItem value="str">str</SelectItem>
+                                                                        <SelectItem value="base64">base64</SelectItem>
+                                                                        <SelectItem value="hex">hex</SelectItem>
                                                                     </SelectContent>
                                                                 </Select>
-                                                                <FormMessage />
-                                                            </FormItem>
-                                                        )}
-                                                    />
-
-                                                    <FormField
-                                                        control={form.control}
-                                                        name="transport_settings.xhttp_settings.no_grpc_header"
-                                                        render={({ field }) => (
-                                                            <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
-                                                                <div className="space-y-0.5">
-                                                                    <FormLabel className="text-base">{t("hostsDialog.xhttp.noGrpcHeader")}</FormLabel>
-                                                                </div>
-                                                                <FormControl>
-                                                                    <Switch checked={field.value} onCheckedChange={field.onChange} />
-                                                                </FormControl>
-                                                            </FormItem>
-                                                        )}
-                                                    />
+                                                                <Input
+                                                                    placeholder={t("hostsDialog.noise.packetPlaceholder")}
+                                                                    value={form.watch(`noise_settings.xray.${index}.packet`) || ""}
+                                                                    onChange={(e) => {
+                                                                        form.setValue(`noise_settings.xray.${index}.packet`, e.target.value, {
+                                                                            shouldDirty: true,
+                                                                            shouldTouch: true
+                                                                        });
+                                                                    }}
+                                                                />
+                                                                <Input
+                                                                    placeholder={t("hostsDialog.noise.delayPlaceholder")}
+                                                                    value={form.watch(`noise_settings.xray.${index}.delay`) || ""}
+                                                                    onChange={(e) => {
+                                                                        form.setValue(`noise_settings.xray.${index}.delay`, e.target.value, {
+                                                                            shouldDirty: true,
+                                                                            shouldTouch: true
+                                                                        });
+                                                                    }}
+                                                                />
+                                                            </div>
+                                                            <Button
+                                                                type="button"
+                                                                variant="ghost"
+                                                                size="icon"
+                                                                className="h-8 w-8 border-red-500"
+                                                                onClick={() => {
+                                                                    const currentNoiseSettings = [...(form.getValues("noise_settings.xray") || [])];
+                                                                    currentNoiseSettings.splice(index, 1);
+                                                                    form.setValue("noise_settings.xray", currentNoiseSettings, {
+                                                                        shouldDirty: true,
+                                                                        shouldTouch: true
+                                                                    });
+                                                                }}
+                                                                title={t("hostsDialog.noise.removeNoise")}
+                                                            >
+                                                                <Trash2 className="h-4 w-4 text-red-500" />
+                                                            </Button>
+                                                        </div>
+                                                    ))}
                                                 </div>
+                                            </div>
+                                        </div>
+                                    </AccordionContent>
+                                </AccordionItem>
 
-                                                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                                    <FormField
-                                                        control={form.control}
-                                                        name="transport_settings.xhttp_settings.x_padding_bytes"
-                                                        render={({ field }) => (
-                                                            <FormItem>
-                                                                <FormLabel>{t("hostsDialog.xhttp.xPaddingBytes")}</FormLabel>
-                                                                <FormControl>
-                                                                    <Input {...field} />
-                                                                </FormControl>
-                                                                <FormMessage />
-                                                            </FormItem>
-                                                        )}
-                                                    />
+                                <AccordionItem className="border px-4 rounded-sm [&_[data-state=open]]:no-underline [&_[data-state=closed]]:no-underline" value="transport">
+                                    <AccordionTrigger>
+                                        <div className="flex items-center gap-2">
+                                            <Network className="h-4 w-4" />
+                                            <span>{t("hostsDialog.transportSettingsAccordion")}</span>
+                                        </div>
+                                    </AccordionTrigger>
+                                    <AccordionContent>
+                                        <div className="space-y-4">
+                                            <Tabs defaultValue="xhttp" className="w-full">
+                                                <TabsList className="grid grid-cols-5 mb-4 gap-4 px-1 min-w-full overflow-x-auto">
+                                                    <TabsTrigger className="px-2" value="xhttp">XHTTP</TabsTrigger>
+                                                    <TabsTrigger className="px-2" value="grpc">gRPC</TabsTrigger>
+                                                    <TabsTrigger className="px-2" value="kcp">KCP</TabsTrigger>
+                                                    <TabsTrigger className="px-2" value="tcp">TCP</TabsTrigger>
+                                                    <TabsTrigger className="px-2" value="websocket">WebSocket</TabsTrigger>
+                                                </TabsList>
 
-                                                    <FormField
-                                                        control={form.control}
-                                                        name="transport_settings.xhttp_settings.sc_max_each_post_bytes"
-                                                        render={({ field }) => (
-                                                            <FormItem>
-                                                                <FormLabel>{t("hostsDialog.xhttp.scMaxEachPostBytes")}</FormLabel>
-                                                                <FormControl>
-                                                                    <Input {...field} />
-                                                                </FormControl>
-                                                                <FormMessage />
-                                                            </FormItem>
-                                                        )}
-                                                    />
-
-                                                    <FormField
-                                                        control={form.control}
-                                                        name="transport_settings.xhttp_settings.sc_min_posts_interval_ms"
-                                                        render={({ field }) => (
-                                                            <FormItem>
-                                                                <FormLabel>{t("hostsDialog.xhttp.scMinPostsIntervalMs")}</FormLabel>
-                                                                <FormControl>
-                                                                    <Input {...field} />
-                                                                </FormControl>
-                                                                <FormMessage />
-                                                            </FormItem>
-                                                        )}
-                                                    />
-
-                                                    <FormField
-                                                        control={form.control}
-                                                        name="transport_settings.xhttp_settings.sc_max_buffered_posts"
-                                                        render={({ field }) => (
-                                                            <FormItem>
-                                                                <FormLabel>{t("hostsDialog.xhttp.scMaxBufferedPosts")}</FormLabel>
-                                                                <FormControl>
-                                                                    <Input {...field} />
-                                                                </FormControl>
-                                                                <FormMessage />
-                                                            </FormItem>
-                                                        )}
-                                                    />
-
-                                                    <FormField
-                                                        control={form.control}
-                                                        name="transport_settings.xhttp_settings.sc_stream_up_server_secs"
-                                                        render={({ field }) => (
-                                                            <FormItem>
-                                                                <FormLabel>{t("hostsDialog.xhttp.scStreamUpServerSecs")}</FormLabel>
-                                                                <FormControl>
-                                                                    <Input {...field} />
-                                                                </FormControl>
-                                                                <FormMessage />
-                                                            </FormItem>
-                                                        )}
-                                                    />
-                                                </div>
-
-                                                <div className="space-y-4">
-                                                    <h4 className="text-sm font-medium">{t("hostsDialog.xhttp.xmux")}</h4>
+                                                {/* XHTTP Settings */}
+                                                <TabsContent dir={dir} value="xhttp" className="space-y-4 p-2">
                                                     <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                                                         <FormField
                                                             control={form.control}
-                                                            name="transport_settings.xhttp_settings.xmux.max_concurrency"
+                                                            name="transport_settings.xhttp_settings.mode"
                                                             render={({ field }) => (
-                                                                <FormItem className="col-span-2 md:col-span-1">
-                                                                    <FormLabel>{t("hostsDialog.xhttp.maxConcurrency")}</FormLabel>
-                                                                    <FormControl>
-                                                                        <Input {...field} />
-                                                                    </FormControl>
-                                                                    <FormMessage />
-                                                                </FormItem>
-                                                            )}
-                                                        />
-
-                                                        <FormField
-                                                            control={form.control}
-                                                            name="transport_settings.xhttp_settings.xmux.max_connections"
-                                                            render={({ field }) => (
-                                                                <FormItem className="col-span-2 md:col-span-1">
-                                                                    <FormLabel>{t("hostsDialog.xhttp.maxConnections")}</FormLabel>
-                                                                    <FormControl>
-                                                                        <Input {...field} />
-                                                                    </FormControl>
-                                                                    <FormMessage />
-                                                                </FormItem>
-                                                            )}
-                                                        />
-
-                                                        <FormField
-                                                            control={form.control}
-                                                            name="transport_settings.xhttp_settings.xmux.c_max_reuse_times"
-                                                            render={({ field }) => (
-                                                                <FormItem className="col-span-2 md:col-span-1">
-                                                                    <FormLabel>{t("hostsDialog.xhttp.cMaxReuseTimes")}</FormLabel>
-                                                                    <FormControl>
-                                                                        <Input {...field} />
-                                                                    </FormControl>
-                                                                    <FormMessage />
-                                                                </FormItem>
-                                                            )}
-                                                        />
-
-                                                        <FormField
-                                                            control={form.control}
-                                                            name="transport_settings.xhttp_settings.xmux.c_max_lifetime"
-                                                            render={({ field }) => (
-                                                                <FormItem className="col-span-2 md:col-span-1">
-                                                                    <FormLabel>{t("hostsDialog.xhttp.cMaxLifetime")}</FormLabel>
-                                                                    <FormControl>
-                                                                        <Input {...field} />
-                                                                    </FormControl>
-                                                                    <FormMessage />
-                                                                </FormItem>
-                                                            )}
-                                                        />
-
-                                                        <FormField
-                                                            control={form.control}
-                                                            name="transport_settings.xhttp_settings.xmux.h_max_request_times"
-                                                            render={({ field }) => (
-                                                                <FormItem className="col-span-2 md:col-span-1">
-                                                                    <FormLabel>{t("hostsDialog.xhttp.hMaxRequestTimes")}</FormLabel>
-                                                                    <FormControl>
-                                                                        <Input {...field} />
-                                                                    </FormControl>
-                                                                    <FormMessage />
-                                                                </FormItem>
-                                                            )}
-                                                        />
-
-                                                        <FormField
-                                                            control={form.control}
-                                                            name="transport_settings.xhttp_settings.xmux.h_keep_alive_period"
-                                                            render={({ field }) => (
-                                                                <FormItem className="col-span-2 md:col-span-1">
-                                                                    <FormLabel>{t("hostsDialog.xhttp.hKeepAlivePeriod")}</FormLabel>
-                                                                    <FormControl>
-                                                                        <Input {...field} />
-                                                                    </FormControl>
-                                                                    <FormMessage />
-                                                                </FormItem>
-                                                            )}
-                                                        />
-                                                        <FormField
-                                                            control={form.control}
-                                                            name="transport_settings.xhttp_settings.download_settings"
-                                                            render={({ field }) => (
-                                                                <FormItem className="w-full col-span-2">
-                                                                    <div className="flex items-center gap-2">
-                                                                        <FormLabel>{t("hostsDialog.xhttp.downloadSettings")}</FormLabel>
-                                                                        <Popover>
-                                                                            <PopoverTrigger asChild>
-                                                                                <Button
-                                                                                    type="button"
-                                                                                    variant="ghost"
-                                                                                    size="icon"
-                                                                                    className="h-4 w-4 p-0 hover:bg-transparent"
-                                                                                >
-                                                                                    <Info className="h-4 w-4 text-muted-foreground" />
-                                                                                </Button>
-                                                                            </PopoverTrigger>
-                                                                            <PopoverContent className="w-[320px] p-3" side="right" align="start" sideOffset={5}>
-                                                                                <p className="text-[11px] text-muted-foreground">
-                                                                                    {t("hostsDialog.xhttp.downloadSettingsInfo")}
-                                                                                </p>
-                                                                            </PopoverContent>
-                                                                        </Popover>
-                                                                    </div>
-                                                                    <Select
-                                                                        onValueChange={(value) => field.onChange(value ? parseInt(value) : 0)}
-                                                                        value={field.value?.toString() ?? "0"}
-                                                                    >
+                                                                <FormItem>
+                                                                    <FormLabel>{t("hostsDialog.xhttp.mode")}</FormLabel>
+                                                                    <Select onValueChange={field.onChange} value={field.value}>
                                                                         <FormControl>
-                                                                            <SelectTrigger className="w-full">
-                                                                                <SelectValue placeholder={t("hostsDialog.xhttp.selectDownloadSettings")} />
+                                                                            <SelectTrigger>
+                                                                                <SelectValue />
                                                                             </SelectTrigger>
                                                                         </FormControl>
-                                                                        <SelectContent className="w-full">
-                                                                            <SelectItem value="0">{t("none")}</SelectItem>
-                                                                            {hosts.map((host) => (
-                                                                                <SelectItem key={host.id} value={host.id?.toString() ?? ""}>
-                                                                                    {host.remark}
-                                                                                </SelectItem>
-                                                                            ))}
+                                                                        <SelectContent>
+                                                                            <SelectItem value="auto">Auto</SelectItem>
+                                                                            <SelectItem value="packet-up">Packet Up</SelectItem>
+                                                                            <SelectItem value="stream-up">Stream Up</SelectItem>
+                                                                            <SelectItem value="stream-one">Stream One</SelectItem>
+                                                                        </SelectContent>
+                                                                    </Select>
+                                                                    <FormMessage />
+                                                                </FormItem>
+                                                            )}
+                                                        />
+
+                                                        <FormField
+                                                            control={form.control}
+                                                            name="transport_settings.xhttp_settings.no_grpc_header"
+                                                            render={({ field }) => (
+                                                                <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
+                                                                    <div className="space-y-0.5">
+                                                                        <FormLabel className="text-base">{t("hostsDialog.xhttp.noGrpcHeader")}</FormLabel>
+                                                                    </div>
+                                                                    <FormControl>
+                                                                        <Switch checked={field.value} onCheckedChange={field.onChange} />
+                                                                    </FormControl>
+                                                                </FormItem>
+                                                            )}
+                                                        />
+                                                    </div>
+
+                                                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                                        <FormField
+                                                            control={form.control}
+                                                            name="transport_settings.xhttp_settings.x_padding_bytes"
+                                                            render={({ field }) => (
+                                                                <FormItem>
+                                                                    <FormLabel>{t("hostsDialog.xhttp.xPaddingBytes")}</FormLabel>
+                                                                    <FormControl>
+                                                                        <Input {...field} />
+                                                                    </FormControl>
+                                                                    <FormMessage />
+                                                                </FormItem>
+                                                            )}
+                                                        />
+
+                                                        <FormField
+                                                            control={form.control}
+                                                            name="transport_settings.xhttp_settings.sc_max_each_post_bytes"
+                                                            render={({ field }) => (
+                                                                <FormItem>
+                                                                    <FormLabel>{t("hostsDialog.xhttp.scMaxEachPostBytes")}</FormLabel>
+                                                                    <FormControl>
+                                                                        <Input {...field} />
+                                                                    </FormControl>
+                                                                    <FormMessage />
+                                                                </FormItem>
+                                                            )}
+                                                        />
+
+                                                        <FormField
+                                                            control={form.control}
+                                                            name="transport_settings.xhttp_settings.sc_min_posts_interval_ms"
+                                                            render={({ field }) => (
+                                                                <FormItem>
+                                                                    <FormLabel>{t("hostsDialog.xhttp.scMinPostsIntervalMs")}</FormLabel>
+                                                                    <FormControl>
+                                                                        <Input {...field} />
+                                                                    </FormControl>
+                                                                    <FormMessage />
+                                                                </FormItem>
+                                                            )}
+                                                        />
+
+                                                        <FormField
+                                                            control={form.control}
+                                                            name="transport_settings.xhttp_settings.sc_max_buffered_posts"
+                                                            render={({ field }) => (
+                                                                <FormItem>
+                                                                    <FormLabel>{t("hostsDialog.xhttp.scMaxBufferedPosts")}</FormLabel>
+                                                                    <FormControl>
+                                                                        <Input {...field} />
+                                                                    </FormControl>
+                                                                    <FormMessage />
+                                                                </FormItem>
+                                                            )}
+                                                        />
+
+                                                        <FormField
+                                                            control={form.control}
+                                                            name="transport_settings.xhttp_settings.sc_stream_up_server_secs"
+                                                            render={({ field }) => (
+                                                                <FormItem>
+                                                                    <FormLabel>{t("hostsDialog.xhttp.scStreamUpServerSecs")}</FormLabel>
+                                                                    <FormControl>
+                                                                        <Input {...field} />
+                                                                    </FormControl>
+                                                                    <FormMessage />
+                                                                </FormItem>
+                                                            )}
+                                                        />
+                                                    </div>
+
+                                                    <div className="space-y-4">
+                                                        <h4 className="text-sm font-medium">{t("hostsDialog.xhttp.xmux")}</h4>
+                                                        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                                            <FormField
+                                                                control={form.control}
+                                                                name="transport_settings.xhttp_settings.xmux.max_concurrency"
+                                                                render={({ field }) => (
+                                                                    <FormItem className="col-span-2 md:col-span-1">
+                                                                        <FormLabel>{t("hostsDialog.xhttp.maxConcurrency")}</FormLabel>
+                                                                        <FormControl>
+                                                                            <Input {...field} />
+                                                                        </FormControl>
+                                                                        <FormMessage />
+                                                                    </FormItem>
+                                                                )}
+                                                            />
+
+                                                            <FormField
+                                                                control={form.control}
+                                                                name="transport_settings.xhttp_settings.xmux.max_connections"
+                                                                render={({ field }) => (
+                                                                    <FormItem className="col-span-2 md:col-span-1">
+                                                                        <FormLabel>{t("hostsDialog.xhttp.maxConnections")}</FormLabel>
+                                                                        <FormControl>
+                                                                            <Input {...field} />
+                                                                        </FormControl>
+                                                                        <FormMessage />
+                                                                    </FormItem>
+                                                                )}
+                                                            />
+
+                                                            <FormField
+                                                                control={form.control}
+                                                                name="transport_settings.xhttp_settings.xmux.c_max_reuse_times"
+                                                                render={({ field }) => (
+                                                                    <FormItem className="col-span-2 md:col-span-1">
+                                                                        <FormLabel>{t("hostsDialog.xhttp.cMaxReuseTimes")}</FormLabel>
+                                                                        <FormControl>
+                                                                            <Input {...field} />
+                                                                        </FormControl>
+                                                                        <FormMessage />
+                                                                    </FormItem>
+                                                                )}
+                                                            />
+
+                                                            <FormField
+                                                                control={form.control}
+                                                                name="transport_settings.xhttp_settings.xmux.c_max_lifetime"
+                                                                render={({ field }) => (
+                                                                    <FormItem className="col-span-2 md:col-span-1">
+                                                                        <FormLabel>{t("hostsDialog.xhttp.cMaxLifetime")}</FormLabel>
+                                                                        <FormControl>
+                                                                            <Input {...field} />
+                                                                        </FormControl>
+                                                                        <FormMessage />
+                                                                    </FormItem>
+                                                                )}
+                                                            />
+
+                                                            <FormField
+                                                                control={form.control}
+                                                                name="transport_settings.xhttp_settings.xmux.h_max_request_times"
+                                                                render={({ field }) => (
+                                                                    <FormItem className="col-span-2 md:col-span-1">
+                                                                        <FormLabel>{t("hostsDialog.xhttp.hMaxRequestTimes")}</FormLabel>
+                                                                        <FormControl>
+                                                                            <Input {...field} />
+                                                                        </FormControl>
+                                                                        <FormMessage />
+                                                                    </FormItem>
+                                                                )}
+                                                            />
+
+                                                            <FormField
+                                                                control={form.control}
+                                                                name="transport_settings.xhttp_settings.xmux.h_keep_alive_period"
+                                                                render={({ field }) => (
+                                                                    <FormItem className="col-span-2 md:col-span-1">
+                                                                        <FormLabel>{t("hostsDialog.xhttp.hKeepAlivePeriod")}</FormLabel>
+                                                                        <FormControl>
+                                                                            <Input {...field} />
+                                                                        </FormControl>
+                                                                        <FormMessage />
+                                                                    </FormItem>
+                                                                )}
+                                                            />
+                                                            <FormField
+                                                                control={form.control}
+                                                                name="transport_settings.xhttp_settings.download_settings"
+                                                                render={({ field }) => (
+                                                                    <FormItem className="w-full col-span-2">
+                                                                        <div className="flex items-center gap-2">
+                                                                            <FormLabel>{t("hostsDialog.xhttp.downloadSettings")}</FormLabel>
+                                                                            <Popover>
+                                                                                <PopoverTrigger asChild>
+                                                                                    <Button
+                                                                                        type="button"
+                                                                                        variant="ghost"
+                                                                                        size="icon"
+                                                                                        className="h-4 w-4 p-0 hover:bg-transparent"
+                                                                                    >
+                                                                                        <Info className="h-4 w-4 text-muted-foreground" />
+                                                                                    </Button>
+                                                                                </PopoverTrigger>
+                                                                                <PopoverContent className="w-[320px] p-3" side="right" align="start" sideOffset={5}>
+                                                                                    <p className="text-[11px] text-muted-foreground">
+                                                                                        {t("hostsDialog.xhttp.downloadSettingsInfo")}
+                                                                                    </p>
+                                                                                </PopoverContent>
+                                                                            </Popover>
+                                                                        </div>
+                                                                        <Select
+                                                                            onValueChange={(value) => field.onChange(value ? parseInt(value) : 0)}
+                                                                            value={field.value?.toString() ?? "0"}
+                                                                        >
+                                                                            <FormControl>
+                                                                                <SelectTrigger className="w-full">
+                                                                                    <SelectValue placeholder={t("hostsDialog.xhttp.selectDownloadSettings")} />
+                                                                                </SelectTrigger>
+                                                                            </FormControl>
+                                                                            <SelectContent className="w-full">
+                                                                                <SelectItem value="0">{t("none")}</SelectItem>
+                                                                                {hosts.map((host) => (
+                                                                                    <SelectItem key={host.id} value={host.id?.toString() ?? ""}>
+                                                                                        {host.remark}
+                                                                                    </SelectItem>
+                                                                                ))}
+                                                                            </SelectContent>
+                                                                        </Select>
+                                                                        <FormMessage />
+                                                                    </FormItem>
+                                                                )}
+                                                            />
+                                                        </div>
+                                                    </div>
+
+                                                </TabsContent>
+
+                                                {/* gRPC Settings */}
+                                                <TabsContent dir={dir} value="grpc" className="space-y-4 p-2">
+                                                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                                        <FormField
+                                                            control={form.control}
+                                                            name="transport_settings.grpc_settings.multi_mode"
+                                                            render={({ field }) => (
+                                                                <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
+                                                                    <div className="space-y-0.5">
+                                                                        <FormLabel className="text-base">{t("hostsDialog.grpc.multiMode")}</FormLabel>
+                                                                    </div>
+                                                                    <FormControl>
+                                                                        <Switch checked={field.value} onCheckedChange={field.onChange} />
+                                                                    </FormControl>
+                                                                </FormItem>
+                                                            )}
+                                                        />
+
+                                                        <FormField
+                                                            control={form.control}
+                                                            name="transport_settings.grpc_settings.idle_timeout"
+                                                            render={({ field }) => (
+                                                                <FormItem>
+                                                                    <FormLabel>{t("hostsDialog.grpc.idleTimeout")}</FormLabel>
+                                                                    <FormControl>
+                                                                        <Input
+                                                                            type="number"
+                                                                            {...field}
+                                                                            onChange={(e) => field.onChange(e.target.value ? Number(e.target.value) : 0)}
+                                                                            value={field.value}
+                                                                        />
+                                                                    </FormControl>
+                                                                    <FormMessage />
+                                                                </FormItem>
+                                                            )}
+                                                        />
+
+                                                        <FormField
+                                                            control={form.control}
+                                                            name="transport_settings.grpc_settings.health_check_timeout"
+                                                            render={({ field }) => (
+                                                                <FormItem>
+                                                                    <FormLabel>{t("hostsDialog.grpc.healthCheckTimeout")}</FormLabel>
+                                                                    <FormControl>
+                                                                        <Input
+                                                                            type="number"
+                                                                            {...field}
+                                                                            onChange={(e) => field.onChange(e.target.value ? Number(e.target.value) : 0)}
+                                                                            value={field.value}
+                                                                        />
+                                                                    </FormControl>
+                                                                    <FormMessage />
+                                                                </FormItem>
+                                                            )}
+                                                        />
+
+                                                        <FormField
+                                                            control={form.control}
+                                                            name="transport_settings.grpc_settings.permit_without_stream"
+                                                            render={({ field }) => (
+                                                                <FormItem>
+                                                                    <FormLabel>{t("hostsDialog.grpc.permitWithoutStream")}</FormLabel>
+                                                                    <FormControl>
+                                                                        <Input
+                                                                            type="number"
+                                                                            {...field}
+                                                                            onChange={(e) => field.onChange(e.target.value ? Number(e.target.value) : 0)}
+                                                                            value={field.value}
+                                                                        />
+                                                                    </FormControl>
+                                                                    <FormMessage />
+                                                                </FormItem>
+                                                            )}
+                                                        />
+
+                                                        <FormField
+                                                            control={form.control}
+                                                            name="transport_settings.grpc_settings.initial_windows_size"
+                                                            render={({ field }) => (
+                                                                <FormItem>
+                                                                    <FormLabel>{t("hostsDialog.grpc.initialWindowsSize")}</FormLabel>
+                                                                    <FormControl>
+                                                                        <Input
+                                                                            type="number"
+                                                                            {...field}
+                                                                            onChange={(e) => field.onChange(e.target.value ? Number(e.target.value) : 0)}
+                                                                            value={field.value}
+                                                                        />
+                                                                    </FormControl>
+                                                                    <FormMessage />
+                                                                </FormItem>
+                                                            )}
+                                                        />
+                                                    </div>
+                                                </TabsContent>
+
+                                                {/* KCP Settings */}
+                                                <TabsContent dir={dir} value="kcp" className="space-y-4 p-2">
+                                                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                                        <FormField
+                                                            control={form.control}
+                                                            name="transport_settings.kcp_settings.header"
+                                                            render={({ field }) => (
+                                                                <FormItem>
+                                                                    <FormLabel>{t("hostsDialog.kcp.header")}</FormLabel>
+                                                                    <Select onValueChange={field.onChange} value={field.value}>
+                                                                        <FormControl>
+                                                                            <SelectTrigger>
+                                                                                <SelectValue />
+                                                                            </SelectTrigger>
+                                                                        </FormControl>
+                                                                        <SelectContent>
+                                                                            <SelectItem value="none">None</SelectItem>
+                                                                            <SelectItem value="srtp">SRTP</SelectItem>
+                                                                            <SelectItem value="utp">uTP</SelectItem>
+                                                                            <SelectItem value="wechat-video">WeChat Video</SelectItem>
+                                                                            <SelectItem value="dtls">DTLS</SelectItem>
+                                                                            <SelectItem value="wireguard">WireGuard</SelectItem>
+                                                                        </SelectContent>
+                                                                    </Select>
+                                                                    <FormMessage />
+                                                                </FormItem>
+                                                            )}
+                                                        />
+
+                                                        <FormField
+                                                            control={form.control}
+                                                            name="transport_settings.kcp_settings.mtu"
+                                                            render={({ field }) => (
+                                                                <FormItem>
+                                                                    <FormLabel>{t("hostsDialog.kcp.mtu")}</FormLabel>
+                                                                    <FormControl>
+                                                                        <Input
+                                                                            type="number"
+                                                                            {...field}
+                                                                            onChange={(e) => field.onChange(e.target.value ? Number(e.target.value) : 0)}
+                                                                            value={field.value}
+                                                                        />
+                                                                    </FormControl>
+                                                                    <FormMessage />
+                                                                </FormItem>
+                                                            )}
+                                                        />
+
+                                                        <FormField
+                                                            control={form.control}
+                                                            name="transport_settings.kcp_settings.tti"
+                                                            render={({ field }) => (
+                                                                <FormItem>
+                                                                    <FormLabel>{t("hostsDialog.kcp.tti")}</FormLabel>
+                                                                    <FormControl>
+                                                                        <Input
+                                                                            type="number"
+                                                                            {...field}
+                                                                            onChange={(e) => field.onChange(e.target.value ? Number(e.target.value) : 0)}
+                                                                            value={field.value}
+                                                                        />
+                                                                    </FormControl>
+                                                                    <FormMessage />
+                                                                </FormItem>
+                                                            )}
+                                                        />
+
+                                                        <FormField
+                                                            control={form.control}
+                                                            name="transport_settings.kcp_settings.uplink_capacity"
+                                                            render={({ field }) => (
+                                                                <FormItem>
+                                                                    <FormLabel>{t("hostsDialog.kcp.uplinkCapacity")}</FormLabel>
+                                                                    <FormControl>
+                                                                        <Input
+                                                                            type="number"
+                                                                            {...field}
+                                                                            onChange={(e) => field.onChange(e.target.value ? Number(e.target.value) : 0)}
+                                                                            value={field.value}
+                                                                        />
+                                                                    </FormControl>
+                                                                    <FormMessage />
+                                                                </FormItem>
+                                                            )}
+                                                        />
+
+                                                        <FormField
+                                                            control={form.control}
+                                                            name="transport_settings.kcp_settings.downlink_capacity"
+                                                            render={({ field }) => (
+                                                                <FormItem>
+                                                                    <FormLabel>{t("hostsDialog.kcp.downlinkCapacity")}</FormLabel>
+                                                                    <FormControl>
+                                                                        <Input
+                                                                            type="number"
+                                                                            {...field}
+                                                                            onChange={(e) => field.onChange(e.target.value ? Number(e.target.value) : 0)}
+                                                                            value={field.value}
+                                                                        />
+                                                                    </FormControl>
+                                                                    <FormMessage />
+                                                                </FormItem>
+                                                            )}
+                                                        />
+
+                                                        <FormField
+                                                            control={form.control}
+                                                            name="transport_settings.kcp_settings.congestion"
+                                                            render={({ field }) => (
+                                                                <FormItem>
+                                                                    <FormLabel>{t("hostsDialog.kcp.congestion")}</FormLabel>
+                                                                    <FormControl>
+                                                                        <Input
+                                                                            type="number"
+                                                                            {...field}
+                                                                            onChange={(e) => field.onChange(e.target.value ? Number(e.target.value) : 0)}
+                                                                            value={field.value}
+                                                                        />
+                                                                    </FormControl>
+                                                                    <FormMessage />
+                                                                </FormItem>
+                                                            )}
+                                                        />
+
+                                                        <FormField
+                                                            control={form.control}
+                                                            name="transport_settings.kcp_settings.read_buffer_size"
+                                                            render={({ field }) => (
+                                                                <FormItem>
+                                                                    <FormLabel>{t("hostsDialog.kcp.readBufferSize")}</FormLabel>
+                                                                    <FormControl>
+                                                                        <Input
+                                                                            type="number"
+                                                                            {...field}
+                                                                            onChange={(e) => field.onChange(e.target.value ? Number(e.target.value) : 0)}
+                                                                            value={field.value}
+                                                                        />
+                                                                    </FormControl>
+                                                                    <FormMessage />
+                                                                </FormItem>
+                                                            )}
+                                                        />
+
+                                                        <FormField
+                                                            control={form.control}
+                                                            name="transport_settings.kcp_settings.write_buffer_size"
+                                                            render={({ field }) => (
+                                                                <FormItem>
+                                                                    <FormLabel>{t("hostsDialog.kcp.writeBufferSize")}</FormLabel>
+                                                                    <FormControl>
+                                                                        <Input
+                                                                            type="number"
+                                                                            {...field}
+                                                                            onChange={(e) => field.onChange(e.target.value ? Number(e.target.value) : 0)}
+                                                                            value={field.value}
+                                                                        />
+                                                                    </FormControl>
+                                                                    <FormMessage />
+                                                                </FormItem>
+                                                            )}
+                                                        />
+                                                    </div>
+                                                </TabsContent>
+
+                                                {/* TCP Settings */}
+                                                <TabsContent dir={dir} value="tcp" className="space-y-4 p-2">
+                                                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                                        <FormField
+                                                            control={form.control}
+                                                            name="transport_settings.tcp_settings.header"
+                                                            render={({ field }) => (
+                                                                <FormItem className="col-span-2">
+                                                                    <FormLabel>{t("hostsDialog.tcp.header")}</FormLabel>
+                                                                    <Select onValueChange={field.onChange} value={field.value}>
+                                                                        <FormControl>
+                                                                            <SelectTrigger>
+                                                                                <SelectValue />
+                                                                            </SelectTrigger>
+                                                                        </FormControl>
+                                                                        <SelectContent>
+                                                                            <SelectItem value="none">None</SelectItem>
+                                                                            <SelectItem value="http">HTTP</SelectItem>
                                                                         </SelectContent>
                                                                     </Select>
                                                                     <FormMessage />
@@ -1347,469 +1638,582 @@ const HostModal: React.FC<HostModalProps> = ({
                                                             )}
                                                         />
                                                     </div>
-                                                </div>
 
-                                            </TabsContent>
-
-                                            {/* gRPC Settings */}
-                                            <TabsContent dir={dir} value="grpc" className="space-y-4 p-2">
-                                                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                                    <FormField
-                                                        control={form.control}
-                                                        name="transport_settings.grpc_settings.multi_mode"
-                                                        render={({ field }) => (
-                                                            <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
-                                                                <div className="space-y-0.5">
-                                                                    <FormLabel className="text-base">{t("hostsDialog.grpc.multiMode")}</FormLabel>
-                                                                </div>
-                                                                <FormControl>
-                                                                    <Switch checked={field.value} onCheckedChange={field.onChange} />
-                                                                </FormControl>
-                                                            </FormItem>
-                                                        )}
-                                                    />
-
-                                                    <FormField
-                                                        control={form.control}
-                                                        name="transport_settings.grpc_settings.idle_timeout"
-                                                        render={({ field }) => (
-                                                            <FormItem>
-                                                                <FormLabel>{t("hostsDialog.grpc.idleTimeout")}</FormLabel>
-                                                                <FormControl>
-                                                                    <Input
-                                                                        type="number"
-                                                                        {...field}
-                                                                        onChange={(e) => field.onChange(e.target.value ? Number(e.target.value) : 0)}
-                                                                        value={field.value}
+                                                    {form.watch("transport_settings.tcp_settings.header") === "http" && (
+                                                        <>
+                                                            <div className="space-y-4 p-2">
+                                                                <h4 className="text-sm font-medium">{t("hostsDialog.tcp.request.title")}</h4>
+                                                                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                                                    <FormField
+                                                                        control={form.control}
+                                                                        name="transport_settings.tcp_settings.request.version"
+                                                                        render={({ field }) => (
+                                                                            <FormItem>
+                                                                                <FormLabel>{t("hostsDialog.tcp.request.version")}</FormLabel>
+                                                                                <Select onValueChange={field.onChange} value={field.value}>
+                                                                                    <FormControl>
+                                                                                        <SelectTrigger>
+                                                                                            <SelectValue />
+                                                                                        </SelectTrigger>
+                                                                                    </FormControl>
+                                                                                    <SelectContent>
+                                                                                        <SelectItem value="1.0">HTTP/1.0</SelectItem>
+                                                                                        <SelectItem value="1.1">HTTP/1.1</SelectItem>
+                                                                                        <SelectItem value="2.0">HTTP/2.0</SelectItem>
+                                                                                        <SelectItem value="3.0">HTTP/3.0</SelectItem>
+                                                                                    </SelectContent>
+                                                                                </Select>
+                                                                                <FormMessage />
+                                                                            </FormItem>
+                                                                        )}
                                                                     />
-                                                                </FormControl>
-                                                                <FormMessage />
-                                                            </FormItem>
-                                                        )}
-                                                    />
 
-                                                    <FormField
-                                                        control={form.control}
-                                                        name="transport_settings.grpc_settings.health_check_timeout"
-                                                        render={({ field }) => (
-                                                            <FormItem>
-                                                                <FormLabel>{t("hostsDialog.grpc.healthCheckTimeout")}</FormLabel>
-                                                                <FormControl>
-                                                                    <Input
-                                                                        type="number"
-                                                                        {...field}
-                                                                        onChange={(e) => field.onChange(e.target.value ? Number(e.target.value) : 0)}
-                                                                        value={field.value}
+                                                                    <FormField
+                                                                        control={form.control}
+                                                                        name="transport_settings.tcp_settings.request.method"
+                                                                        render={({ field }) => (
+                                                                            <FormItem>
+                                                                                <FormLabel>{t("hostsDialog.tcp.request.method")}</FormLabel>
+                                                                                <Select onValueChange={field.onChange} value={field.value}>
+                                                                                    <FormControl>
+                                                                                        <SelectTrigger>
+                                                                                            <SelectValue />
+                                                                                        </SelectTrigger>
+                                                                                    </FormControl>
+                                                                                    <SelectContent>
+                                                                                        <SelectItem value="GET">GET</SelectItem>
+                                                                                        <SelectItem value="POST">POST</SelectItem>
+                                                                                        <SelectItem value="PUT">PUT</SelectItem>
+                                                                                        <SelectItem value="DELETE">DELETE</SelectItem>
+                                                                                        <SelectItem value="HEAD">HEAD</SelectItem>
+                                                                                        <SelectItem value="OPTIONS">OPTIONS</SelectItem>
+                                                                                        <SelectItem value="PATCH">PATCH</SelectItem>
+                                                                                        <SelectItem value="TRACE">TRACE</SelectItem>
+                                                                                        <SelectItem value="CONNECT">CONNECT</SelectItem>
+                                                                                    </SelectContent>
+                                                                                </Select>
+                                                                                <FormMessage />
+                                                                            </FormItem>
+                                                                        )}
                                                                     />
-                                                                </FormControl>
-                                                                <FormMessage />
-                                                            </FormItem>
-                                                        )}
-                                                    />
-
-                                                    <FormField
-                                                        control={form.control}
-                                                        name="transport_settings.grpc_settings.permit_without_stream"
-                                                        render={({ field }) => (
-                                                            <FormItem>
-                                                                <FormLabel>{t("hostsDialog.grpc.permitWithoutStream")}</FormLabel>
-                                                                <FormControl>
-                                                                    <Input
-                                                                        type="number"
-                                                                        {...field}
-                                                                        onChange={(e) => field.onChange(e.target.value ? Number(e.target.value) : 0)}
-                                                                        value={field.value}
-                                                                    />
-                                                                </FormControl>
-                                                                <FormMessage />
-                                                            </FormItem>
-                                                        )}
-                                                    />
-
-                                                    <FormField
-                                                        control={form.control}
-                                                        name="transport_settings.grpc_settings.initial_windows_size"
-                                                        render={({ field }) => (
-                                                            <FormItem>
-                                                                <FormLabel>{t("hostsDialog.grpc.initialWindowsSize")}</FormLabel>
-                                                                <FormControl>
-                                                                    <Input
-                                                                        type="number"
-                                                                        {...field}
-                                                                        onChange={(e) => field.onChange(e.target.value ? Number(e.target.value) : 0)}
-                                                                        value={field.value}
-                                                                    />
-                                                                </FormControl>
-                                                                <FormMessage />
-                                                            </FormItem>
-                                                        )}
-                                                    />
-                                                </div>
-                                            </TabsContent>
-
-                                            {/* KCP Settings */}
-                                            <TabsContent dir={dir} value="kcp" className="space-y-4 p-2">
-                                                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                                    <FormField
-                                                        control={form.control}
-                                                        name="transport_settings.kcp_settings.header"
-                                                        render={({ field }) => (
-                                                            <FormItem>
-                                                                <FormLabel>{t("hostsDialog.kcp.header")}</FormLabel>
-                                                                <Select onValueChange={field.onChange} value={field.value}>
-                                                                    <FormControl>
-                                                                        <SelectTrigger>
-                                                                            <SelectValue />
-                                                                        </SelectTrigger>
-                                                                    </FormControl>
-                                                                    <SelectContent>
-                                                                        <SelectItem value="none">None</SelectItem>
-                                                                        <SelectItem value="srtp">SRTP</SelectItem>
-                                                                        <SelectItem value="utp">uTP</SelectItem>
-                                                                        <SelectItem value="wechat-video">WeChat Video</SelectItem>
-                                                                        <SelectItem value="dtls">DTLS</SelectItem>
-                                                                        <SelectItem value="wireguard">WireGuard</SelectItem>
-                                                                    </SelectContent>
-                                                                </Select>
-                                                                <FormMessage />
-                                                            </FormItem>
-                                                        )}
-                                                    />
-
-                                                    <FormField
-                                                        control={form.control}
-                                                        name="transport_settings.kcp_settings.mtu"
-                                                        render={({ field }) => (
-                                                            <FormItem>
-                                                                <FormLabel>{t("hostsDialog.kcp.mtu")}</FormLabel>
-                                                                <FormControl>
-                                                                    <Input
-                                                                        type="number"
-                                                                        {...field}
-                                                                        onChange={(e) => field.onChange(e.target.value ? Number(e.target.value) : 0)}
-                                                                        value={field.value}
-                                                                    />
-                                                                </FormControl>
-                                                                <FormMessage />
-                                                            </FormItem>
-                                                        )}
-                                                    />
-
-                                                    <FormField
-                                                        control={form.control}
-                                                        name="transport_settings.kcp_settings.tti"
-                                                        render={({ field }) => (
-                                                            <FormItem>
-                                                                <FormLabel>{t("hostsDialog.kcp.tti")}</FormLabel>
-                                                                <FormControl>
-                                                                    <Input
-                                                                        type="number"
-                                                                        {...field}
-                                                                        onChange={(e) => field.onChange(e.target.value ? Number(e.target.value) : 0)}
-                                                                        value={field.value}
-                                                                    />
-                                                                </FormControl>
-                                                                <FormMessage />
-                                                            </FormItem>
-                                                        )}
-                                                    />
-
-                                                    <FormField
-                                                        control={form.control}
-                                                        name="transport_settings.kcp_settings.uplink_capacity"
-                                                        render={({ field }) => (
-                                                            <FormItem>
-                                                                <FormLabel>{t("hostsDialog.kcp.uplinkCapacity")}</FormLabel>
-                                                                <FormControl>
-                                                                    <Input
-                                                                        type="number"
-                                                                        {...field}
-                                                                        onChange={(e) => field.onChange(e.target.value ? Number(e.target.value) : 0)}
-                                                                        value={field.value}
-                                                                    />
-                                                                </FormControl>
-                                                                <FormMessage />
-                                                            </FormItem>
-                                                        )}
-                                                    />
-
-                                                    <FormField
-                                                        control={form.control}
-                                                        name="transport_settings.kcp_settings.downlink_capacity"
-                                                        render={({ field }) => (
-                                                            <FormItem>
-                                                                <FormLabel>{t("hostsDialog.kcp.downlinkCapacity")}</FormLabel>
-                                                                <FormControl>
-                                                                    <Input
-                                                                        type="number"
-                                                                        {...field}
-                                                                        onChange={(e) => field.onChange(e.target.value ? Number(e.target.value) : 0)}
-                                                                        value={field.value}
-                                                                    />
-                                                                </FormControl>
-                                                                <FormMessage />
-                                                            </FormItem>
-                                                        )}
-                                                    />
-
-                                                    <FormField
-                                                        control={form.control}
-                                                        name="transport_settings.kcp_settings.congestion"
-                                                        render={({ field }) => (
-                                                            <FormItem>
-                                                                <FormLabel>{t("hostsDialog.kcp.congestion")}</FormLabel>
-                                                                <FormControl>
-                                                                    <Input
-                                                                        type="number"
-                                                                        {...field}
-                                                                        onChange={(e) => field.onChange(e.target.value ? Number(e.target.value) : 0)}
-                                                                        value={field.value}
-                                                                    />
-                                                                </FormControl>
-                                                                <FormMessage />
-                                                            </FormItem>
-                                                        )}
-                                                    />
-
-                                                    <FormField
-                                                        control={form.control}
-                                                        name="transport_settings.kcp_settings.read_buffer_size"
-                                                        render={({ field }) => (
-                                                            <FormItem>
-                                                                <FormLabel>{t("hostsDialog.kcp.readBufferSize")}</FormLabel>
-                                                                <FormControl>
-                                                                    <Input
-                                                                        type="number"
-                                                                        {...field}
-                                                                        onChange={(e) => field.onChange(e.target.value ? Number(e.target.value) : 0)}
-                                                                        value={field.value}
-                                                                    />
-                                                                </FormControl>
-                                                                <FormMessage />
-                                                            </FormItem>
-                                                        )}
-                                                    />
-
-                                                    <FormField
-                                                        control={form.control}
-                                                        name="transport_settings.kcp_settings.write_buffer_size"
-                                                        render={({ field }) => (
-                                                            <FormItem>
-                                                                <FormLabel>{t("hostsDialog.kcp.writeBufferSize")}</FormLabel>
-                                                                <FormControl>
-                                                                    <Input
-                                                                        type="number"
-                                                                        {...field}
-                                                                        onChange={(e) => field.onChange(e.target.value ? Number(e.target.value) : 0)}
-                                                                        value={field.value}
-                                                                    />
-                                                                </FormControl>
-                                                                <FormMessage />
-                                                            </FormItem>
-                                                        )}
-                                                    />
-                                                </div>
-                                            </TabsContent>
-
-                                            {/* TCP Settings */}
-                                            <TabsContent dir={dir} value="tcp" className="space-y-4 p-2">
-                                                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                                    <FormField
-                                                        control={form.control}
-                                                        name="transport_settings.tcp_settings.header"
-                                                        render={({ field }) => (
-                                                            <FormItem className="col-span-2">
-                                                                <FormLabel>{t("hostsDialog.tcp.header")}</FormLabel>
-                                                                <Select onValueChange={field.onChange} value={field.value}>
-                                                                    <FormControl>
-                                                                        <SelectTrigger>
-                                                                            <SelectValue />
-                                                                        </SelectTrigger>
-                                                                    </FormControl>
-                                                                    <SelectContent>
-                                                                        <SelectItem value="none">None</SelectItem>
-                                                                        <SelectItem value="http">HTTP</SelectItem>
-                                                                    </SelectContent>
-                                                                </Select>
-                                                                <FormMessage />
-                                                            </FormItem>
-                                                        )}
-                                                    />
-                                                </div>
-
-                                                {form.watch("transport_settings.tcp_settings.header") === "http" && (
-                                                    <>
-                                                        <div className="space-y-4 p-2">
-                                                            <h4 className="text-sm font-medium">{t("hostsDialog.tcp.request.title")}</h4>
-                                                            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                                                <FormField
-                                                                    control={form.control}
-                                                                    name="transport_settings.tcp_settings.request.version"
-                                                                    render={({ field }) => (
-                                                                        <FormItem>
-                                                                            <FormLabel>{t("hostsDialog.tcp.request.version")}</FormLabel>
-                                                                            <Select onValueChange={field.onChange} value={field.value}>
-                                                                                <FormControl>
-                                                                                    <SelectTrigger>
-                                                                                        <SelectValue />
-                                                                                    </SelectTrigger>
-                                                                                </FormControl>
-                                                                                <SelectContent>
-                                                                                    <SelectItem value="1.0">HTTP/1.0</SelectItem>
-                                                                                    <SelectItem value="1.1">HTTP/1.1</SelectItem>
-                                                                                    <SelectItem value="2.0">HTTP/2.0</SelectItem>
-                                                                                    <SelectItem value="3.0">HTTP/3.0</SelectItem>
-                                                                                </SelectContent>
-                                                                            </Select>
-                                                                            <FormMessage />
-                                                                        </FormItem>
-                                                                    )}
-                                                                />
-
-                                                                <FormField
-                                                                    control={form.control}
-                                                                    name="transport_settings.tcp_settings.request.method"
-                                                                    render={({ field }) => (
-                                                                        <FormItem>
-                                                                            <FormLabel>{t("hostsDialog.tcp.request.method")}</FormLabel>
-                                                                            <Select onValueChange={field.onChange} value={field.value}>
-                                                                                <FormControl>
-                                                                                    <SelectTrigger>
-                                                                                        <SelectValue />
-                                                                                    </SelectTrigger>
-                                                                                </FormControl>
-                                                                                <SelectContent>
-                                                                                    <SelectItem value="GET">GET</SelectItem>
-                                                                                    <SelectItem value="POST">POST</SelectItem>
-                                                                                    <SelectItem value="PUT">PUT</SelectItem>
-                                                                                    <SelectItem value="DELETE">DELETE</SelectItem>
-                                                                                    <SelectItem value="HEAD">HEAD</SelectItem>
-                                                                                    <SelectItem value="OPTIONS">OPTIONS</SelectItem>
-                                                                                    <SelectItem value="PATCH">PATCH</SelectItem>
-                                                                                    <SelectItem value="TRACE">TRACE</SelectItem>
-                                                                                    <SelectItem value="CONNECT">CONNECT</SelectItem>
-                                                                                </SelectContent>
-                                                                            </Select>
-                                                                            <FormMessage />
-                                                                        </FormItem>
-                                                                    )}
-                                                                />
-                                                            </div>
-
-                                                            {/* Request Headers */}
-                                                            <div className="space-y-2">
-                                                                <div className="flex items-center justify-between">
-                                                                    <h4 className="text-sm font-medium">{t("hostsDialog.tcp.requestHeaders")}</h4>
-                                                                    <Button
-                                                                        type="button"
-                                                                        variant="outline"
-                                                                        size="icon"
-                                                                        className="h-6 w-6"
-                                                                        onClick={() => {
-                                                                            const currentHeaders = form.getValues("transport_settings.tcp_settings.request.headers") || {};
-                                                                            const newKey = `header_${Object.keys(currentHeaders).length}`;
-                                                                            form.setValue("transport_settings.tcp_settings.request.headers", {
-                                                                                ...currentHeaders,
-                                                                                [newKey]: [""]
-                                                                            }, {
-                                                                                shouldDirty: true,
-                                                                                shouldTouch: true
-                                                                            });
-                                                                        }}
-                                                                    >
-                                                                        <Plus className="h-4 w-4" />
-                                                                    </Button>
                                                                 </div>
 
-                                                                {/* Render request headers */}
-                                                                {Object.entries(form.watch("transport_settings.tcp_settings.request.headers") || {}).map(([key, values]) => (
-                                                                    <div key={key} className="grid grid-cols-[1fr,2fr,auto] gap-2">
-                                                                        <Input
-                                                                            placeholder={t("hostsDialog.tcp.headerName")}
-                                                                            defaultValue={key}
-                                                                            onBlur={(e) => {
-                                                                                if (e.target.value !== key) {
-                                                                                    const currentHeaders = { ...form.getValues("transport_settings.tcp_settings.request.headers") };
-                                                                                    const oldValues = currentHeaders[key];
-                                                                                    delete currentHeaders[key];
-                                                                                    currentHeaders[e.target.value] = oldValues;
-                                                                                    form.setValue("transport_settings.tcp_settings.request.headers", currentHeaders, {
-                                                                                        shouldDirty: true,
-                                                                                        shouldTouch: true
-                                                                                    });
-                                                                                }
-                                                                            }}
-                                                                        />
-                                                                        <Input
-                                                                            placeholder={t("hostsDialog.tcp.headerValue")}
-                                                                            value={values.join(", ")}
-                                                                            onChange={(e) => {
-                                                                                const currentHeaders = { ...form.getValues("transport_settings.tcp_settings.request.headers") };
-                                                                                currentHeaders[key] = e.target.value.split(",").map(v => v.trim());
-                                                                                form.setValue("transport_settings.tcp_settings.request.headers", currentHeaders, {
-                                                                                    shouldDirty: true,
-                                                                                    shouldTouch: true
-                                                                                });
-                                                                            }}
-                                                                        />
+                                                                {/* Request Headers */}
+                                                                <div className="space-y-2">
+                                                                    <div className="flex items-center justify-between">
+                                                                        <h4 className="text-sm font-medium">{t("hostsDialog.tcp.requestHeaders")}</h4>
                                                                         <Button
                                                                             type="button"
-                                                                            variant="ghost"
+                                                                            variant="outline"
                                                                             size="icon"
+                                                                            className="h-6 w-6"
                                                                             onClick={() => {
-                                                                                const currentHeaders = { ...form.getValues("transport_settings.tcp_settings.request.headers") };
-                                                                                delete currentHeaders[key];
-                                                                                form.setValue("transport_settings.tcp_settings.request.headers", currentHeaders, {
+                                                                                const currentHeaders = form.getValues("transport_settings.tcp_settings.request.headers") || {};
+                                                                                const newKey = `header_${Object.keys(currentHeaders).length}`;
+                                                                                form.setValue("transport_settings.tcp_settings.request.headers", {
+                                                                                    ...currentHeaders,
+                                                                                    [newKey]: [""]
+                                                                                }, {
                                                                                     shouldDirty: true,
                                                                                     shouldTouch: true
                                                                                 });
                                                                             }}
                                                                         >
-                                                                            <Trash2 className="h-4 w-4 text-red-500" />
+                                                                            <Plus className="h-4 w-4" />
                                                                         </Button>
                                                                     </div>
-                                                                ))}
+
+                                                                    {/* Render request headers */}
+                                                                    {Object.entries(form.watch("transport_settings.tcp_settings.request.headers") || {}).map(([key, values]) => (
+                                                                        <div key={key} className="grid grid-cols-[1fr,2fr,auto] gap-2">
+                                                                            <Input
+                                                                                placeholder={t("hostsDialog.tcp.headerName")}
+                                                                                defaultValue={key}
+                                                                                onBlur={(e) => {
+                                                                                    if (e.target.value !== key) {
+                                                                                        const currentHeaders = { ...form.getValues("transport_settings.tcp_settings.request.headers") };
+                                                                                        const oldValues = currentHeaders[key];
+                                                                                        delete currentHeaders[key];
+                                                                                        currentHeaders[e.target.value] = oldValues;
+                                                                                        form.setValue("transport_settings.tcp_settings.request.headers", currentHeaders, {
+                                                                                            shouldDirty: true,
+                                                                                            shouldTouch: true
+                                                                                        });
+                                                                                    }
+                                                                                }}
+                                                                            />
+                                                                            <Input
+                                                                                placeholder={t("hostsDialog.tcp.headerValue")}
+                                                                                value={values.join(", ")}
+                                                                                onChange={(e) => {
+                                                                                    const currentHeaders = { ...form.getValues("transport_settings.tcp_settings.request.headers") };
+                                                                                    currentHeaders[key] = e.target.value.split(",").map(v => v.trim());
+                                                                                    form.setValue("transport_settings.tcp_settings.request.headers", currentHeaders, {
+                                                                                        shouldDirty: true,
+                                                                                        shouldTouch: true
+                                                                                    });
+                                                                                }}
+                                                                            />
+                                                                            <Button
+                                                                                type="button"
+                                                                                variant="ghost"
+                                                                                size="icon"
+                                                                                onClick={() => {
+                                                                                    const currentHeaders = { ...form.getValues("transport_settings.tcp_settings.request.headers") };
+                                                                                    delete currentHeaders[key];
+                                                                                    form.setValue("transport_settings.tcp_settings.request.headers", currentHeaders, {
+                                                                                        shouldDirty: true,
+                                                                                        shouldTouch: true
+                                                                                    });
+                                                                                }}
+                                                                            >
+                                                                                <Trash2 className="h-4 w-4 text-red-500" />
+                                                                            </Button>
+                                                                        </div>
+                                                                    ))}
+                                                                </div>
                                                             </div>
+
+                                                            <div className="space-y-4 p-2">
+                                                                <h4 className="text-sm font-medium">{t("hostsDialog.tcp.response.title")}</h4>
+                                                                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                                                    <FormField
+                                                                        control={form.control}
+                                                                        name="transport_settings.tcp_settings.response.version"
+                                                                        render={({ field }) => (
+                                                                            <FormItem>
+                                                                                <FormLabel>{t("hostsDialog.tcp.response.version")}</FormLabel>
+                                                                                <Select onValueChange={field.onChange} value={field.value}>
+                                                                                    <FormControl>
+                                                                                        <SelectTrigger>
+                                                                                            <SelectValue />
+                                                                                        </SelectTrigger>
+                                                                                    </FormControl>
+                                                                                    <SelectContent>
+                                                                                        <SelectItem value="1.0">HTTP/1.0</SelectItem>
+                                                                                        <SelectItem value="1.1">HTTP/1.1</SelectItem>
+                                                                                        <SelectItem value="2.0">HTTP/2.0</SelectItem>
+                                                                                        <SelectItem value="3.0">HTTP/3.0</SelectItem>
+                                                                                    </SelectContent>
+                                                                                </Select>
+                                                                                <FormMessage />
+                                                                            </FormItem>
+                                                                        )}
+                                                                    />
+
+                                                                    <FormField
+                                                                        control={form.control}
+                                                                        name="transport_settings.tcp_settings.response.status"
+                                                                        render={({ field }) => (
+                                                                            <FormItem>
+                                                                                <FormLabel>{t("hostsDialog.tcp.response.status")}</FormLabel>
+                                                                                <FormControl>
+                                                                                    <Input
+                                                                                        {...field}
+                                                                                        placeholder="200"
+                                                                                        pattern="[1-5]\d{2}"
+                                                                                    />
+                                                                                </FormControl>
+                                                                                <FormMessage />
+                                                                            </FormItem>
+                                                                        )}
+                                                                    />
+
+                                                                    <FormField
+                                                                        control={form.control}
+                                                                        name="transport_settings.tcp_settings.response.reason"
+                                                                        render={({ field }) => (
+                                                                            <FormItem>
+                                                                                <FormLabel>{t("hostsDialog.tcp.response.reason")}</FormLabel>
+                                                                                <Select onValueChange={field.onChange} value={field.value || ""}>
+                                                                                    <FormControl>
+                                                                                        <SelectTrigger>
+                                                                                            <SelectValue placeholder={t("hostsDialog.selectReason")} />
+                                                                                        </SelectTrigger>
+                                                                                    </FormControl>
+                                                                                    <SelectContent>
+                                                                                        {/* 1xx Information responses */}
+                                                                                        <SelectGroup>
+                                                                                            <SelectLabel>1xx Information</SelectLabel>
+                                                                                            <SelectItem value="Continue">{t("hostsDialog.httpReasons.100")}</SelectItem>
+                                                                                            <SelectItem value="Switching Protocols">{t("hostsDialog.httpReasons.101")}</SelectItem>
+                                                                                        </SelectGroup>
+
+                                                                                        {/* 2xx Success responses */}
+                                                                                        <SelectGroup>
+                                                                                            <SelectLabel>2xx Success</SelectLabel>
+                                                                                            <SelectItem value="OK">{t("hostsDialog.httpReasons.200")}</SelectItem>
+                                                                                            <SelectItem value="Created">{t("hostsDialog.httpReasons.201")}</SelectItem>
+                                                                                            <SelectItem value="Accepted">{t("hostsDialog.httpReasons.202")}</SelectItem>
+                                                                                            <SelectItem value="Non-Authoritative Information">{t("hostsDialog.httpReasons.203")}</SelectItem>
+                                                                                            <SelectItem value="No Content">{t("hostsDialog.httpReasons.204")}</SelectItem>
+                                                                                            <SelectItem value="Reset Content">{t("hostsDialog.httpReasons.205")}</SelectItem>
+                                                                                            <SelectItem value="Partial Content">{t("hostsDialog.httpReasons.206")}</SelectItem>
+                                                                                        </SelectGroup>
+
+                                                                                        {/* 3xx Redirection responses */}
+                                                                                        <SelectGroup>
+                                                                                            <SelectLabel>3xx Redirection</SelectLabel>
+                                                                                            <SelectItem value="Multiple Choices">{t("hostsDialog.httpReasons.300")}</SelectItem>
+                                                                                            <SelectItem value="Moved Permanently">{t("hostsDialog.httpReasons.301")}</SelectItem>
+                                                                                            <SelectItem value="Found">{t("hostsDialog.httpReasons.302")}</SelectItem>
+                                                                                            <SelectItem value="See Other">{t("hostsDialog.httpReasons.303")}</SelectItem>
+                                                                                            <SelectItem value="Not Modified">{t("hostsDialog.httpReasons.304")}</SelectItem>
+                                                                                            <SelectItem value="Use Proxy">{t("hostsDialog.httpReasons.305")}</SelectItem>
+                                                                                            <SelectItem value="Temporary Redirect">{t("hostsDialog.httpReasons.307")}</SelectItem>
+                                                                                            <SelectItem value="Permanent Redirect">{t("hostsDialog.httpReasons.308")}</SelectItem>
+                                                                                        </SelectGroup>
+
+                                                                                        {/* 4xx Client Error responses */}
+                                                                                        <SelectGroup>
+                                                                                            <SelectLabel>4xx Client Error</SelectLabel>
+                                                                                            <SelectItem value="Bad Request">{t("hostsDialog.httpReasons.400")}</SelectItem>
+                                                                                            <SelectItem value="Unauthorized">{t("hostsDialog.httpReasons.401")}</SelectItem>
+                                                                                            <SelectItem value="Payment Required">{t("hostsDialog.httpReasons.402")}</SelectItem>
+                                                                                            <SelectItem value="Forbidden">{t("hostsDialog.httpReasons.403")}</SelectItem>
+                                                                                            <SelectItem value="Not Found">{t("hostsDialog.httpReasons.404")}</SelectItem>
+                                                                                            <SelectItem value="Method Not Allowed">{t("hostsDialog.httpReasons.405")}</SelectItem>
+                                                                                            <SelectItem value="Not Acceptable">{t("hostsDialog.httpReasons.406")}</SelectItem>
+                                                                                            <SelectItem value="Proxy Authentication Required">{t("hostsDialog.httpReasons.407")}</SelectItem>
+                                                                                            <SelectItem value="Request Timeout">{t("hostsDialog.httpReasons.408")}</SelectItem>
+                                                                                            <SelectItem value="Conflict">{t("hostsDialog.httpReasons.409")}</SelectItem>
+                                                                                            <SelectItem value="Gone">{t("hostsDialog.httpReasons.410")}</SelectItem>
+                                                                                            <SelectItem value="Length Required">{t("hostsDialog.httpReasons.411")}</SelectItem>
+                                                                                            <SelectItem value="Precondition Failed">{t("hostsDialog.httpReasons.412")}</SelectItem>
+                                                                                            <SelectItem value="Payload Too Large">{t("hostsDialog.httpReasons.413")}</SelectItem>
+                                                                                            <SelectItem value="URI Too Long">{t("hostsDialog.httpReasons.414")}</SelectItem>
+                                                                                            <SelectItem value="Unsupported Media Type">{t("hostsDialog.httpReasons.415")}</SelectItem>
+                                                                                            <SelectItem value="Range Not Satisfiable">{t("hostsDialog.httpReasons.416")}</SelectItem>
+                                                                                            <SelectItem value="Expectation Failed">{t("hostsDialog.httpReasons.417")}</SelectItem>
+                                                                                            <SelectItem value="I'm a teapot">{t("hostsDialog.httpReasons.418")}</SelectItem>
+                                                                                            <SelectItem value="Misdirected Request">{t("hostsDialog.httpReasons.421")}</SelectItem>
+                                                                                            <SelectItem value="Unprocessable Entity">{t("hostsDialog.httpReasons.422")}</SelectItem>
+                                                                                            <SelectItem value="Locked">{t("hostsDialog.httpReasons.423")}</SelectItem>
+                                                                                            <SelectItem value="Failed Dependency">{t("hostsDialog.httpReasons.424")}</SelectItem>
+                                                                                            <SelectItem value="Too Early">{t("hostsDialog.httpReasons.425")}</SelectItem>
+                                                                                            <SelectItem value="Upgrade Required">{t("hostsDialog.httpReasons.426")}</SelectItem>
+                                                                                            <SelectItem value="Precondition Required">{t("hostsDialog.httpReasons.428")}</SelectItem>
+                                                                                            <SelectItem value="Too Many Requests">{t("hostsDialog.httpReasons.429")}</SelectItem>
+                                                                                            <SelectItem value="Request Header Fields Too Large">{t("hostsDialog.httpReasons.431")}</SelectItem>
+                                                                                            <SelectItem value="Unavailable For Legal Reasons">{t("hostsDialog.httpReasons.451")}</SelectItem>
+                                                                                        </SelectGroup>
+
+                                                                                        {/* 5xx Server Error responses */}
+                                                                                        <SelectGroup>
+                                                                                            <SelectLabel>5xx Server Error</SelectLabel>
+                                                                                            <SelectItem value="Internal Server Error">{t("hostsDialog.httpReasons.500")}</SelectItem>
+                                                                                            <SelectItem value="Not Implemented">{t("hostsDialog.httpReasons.501")}</SelectItem>
+                                                                                            <SelectItem value="Bad Gateway">{t("hostsDialog.httpReasons.502")}</SelectItem>
+                                                                                            <SelectItem value="Service Unavailable">{t("hostsDialog.httpReasons.503")}</SelectItem>
+                                                                                            <SelectItem value="Gateway Timeout">{t("hostsDialog.httpReasons.504")}</SelectItem>
+                                                                                            <SelectItem value="HTTP Version Not Supported">{t("hostsDialog.httpReasons.505")}</SelectItem>
+                                                                                        </SelectGroup>
+                                                                                    </SelectContent>
+                                                                                </Select>
+                                                                                <FormMessage />
+                                                                            </FormItem>
+                                                                        )}
+                                                                    />
+                                                                </div>
+
+                                                                {/* Response Headers */}
+                                                                <div className="space-y-2">
+                                                                    <div className="flex items-center justify-between">
+                                                                        <h4 className="text-sm font-medium">{t("hostsDialog.tcp.responseHeaders")}</h4>
+                                                                        <Button
+                                                                            type="button"
+                                                                            variant="outline"
+                                                                            size="icon"
+                                                                            className="h-6 w-6"
+                                                                            onClick={() => {
+                                                                                const currentHeaders = form.getValues("transport_settings.tcp_settings.response.headers") || {};
+                                                                                const newKey = `header_${Object.keys(currentHeaders).length}`;
+                                                                                form.setValue("transport_settings.tcp_settings.response.headers", {
+                                                                                    ...currentHeaders,
+                                                                                    [newKey]: [""]
+                                                                                }, {
+                                                                                    shouldDirty: true,
+                                                                                    shouldTouch: true
+                                                                                });
+                                                                            }}
+                                                                        >
+                                                                            <Plus className="h-4 w-4" />
+                                                                        </Button>
+                                                                    </div>
+
+                                                                    {/* Render response headers */}
+                                                                    {Object.entries(form.watch("transport_settings.tcp_settings.response.headers") || {}).map(([key, values]) => (
+                                                                        <div key={key} className="grid grid-cols-[1fr,2fr,auto] gap-2">
+                                                                            <Input
+                                                                                placeholder={t("hostsDialog.tcp.headerName")}
+                                                                                defaultValue={key}
+                                                                                onBlur={(e) => {
+                                                                                    if (e.target.value !== key) {
+                                                                                        const currentHeaders = { ...form.getValues("transport_settings.tcp_settings.response.headers") };
+                                                                                        const oldValues = currentHeaders[key];
+                                                                                        delete currentHeaders[key];
+                                                                                        currentHeaders[e.target.value] = oldValues;
+                                                                                        form.setValue("transport_settings.tcp_settings.response.headers", currentHeaders, {
+                                                                                            shouldDirty: true,
+                                                                                            shouldTouch: true
+                                                                                        });
+                                                                                    }
+                                                                                }}
+                                                                            />
+                                                                            <Input
+                                                                                placeholder={t("hostsDialog.tcp.headerValue")}
+                                                                                value={values.join(", ")}
+                                                                                onChange={(e) => {
+                                                                                    const currentHeaders = { ...form.getValues("transport_settings.tcp_settings.response.headers") };
+                                                                                    currentHeaders[key] = e.target.value.split(",").map(v => v.trim());
+                                                                                    form.setValue("transport_settings.tcp_settings.response.headers", currentHeaders, {
+                                                                                        shouldDirty: true,
+                                                                                        shouldTouch: true
+                                                                                    });
+                                                                                }}
+                                                                            />
+                                                                            <Button
+                                                                                type="button"
+                                                                                variant="ghost"
+                                                                                size="icon"
+                                                                                onClick={() => {
+                                                                                    const currentHeaders = { ...form.getValues("transport_settings.tcp_settings.response.headers") };
+                                                                                    delete currentHeaders[key];
+                                                                                    form.setValue("transport_settings.tcp_settings.response.headers", currentHeaders, {
+                                                                                        shouldDirty: true,
+                                                                                        shouldTouch: true
+                                                                                    });
+                                                                                }}
+                                                                            >
+                                                                                <Trash2 className="h-4 w-4 text-red-500" />
+                                                                            </Button>
+                                                                        </div>
+                                                                    ))}
+                                                                </div>
+                                                            </div>
+                                                        </>
+                                                    )}
+                                                </TabsContent>
+
+                                                {/* WebSocket Settings */}
+                                                <TabsContent dir={dir} value="websocket" className="space-y-4">
+                                                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                                        <FormField
+                                                            control={form.control}
+                                                            name="transport_settings.websocket_settings.heartbeatPeriod"
+                                                            render={({ field }) => (
+                                                                <FormItem>
+                                                                    <FormLabel>{t("hostsDialog.websocket.heartbeatPeriod")}</FormLabel>
+                                                                    <FormControl>
+                                                                        <Input
+                                                                            type="number"
+                                                                            {...field}
+                                                                            onChange={(e) => field.onChange(e.target.value ? Number(e.target.value) : 0)}
+                                                                            value={field.value}
+                                                                        />
+                                                                    </FormControl>
+                                                                    <FormMessage />
+                                                                </FormItem>
+                                                            )}
+                                                        />
+                                                    </div>
+                                                </TabsContent>
+                                            </Tabs>
+                                        </div>
+                                    </AccordionContent>
+                                </AccordionItem>
+
+                                <AccordionItem className="border px-4 rounded-sm [&_[data-state=open]]:no-underline [&_[data-state=closed]]:no-underline" value="mux">
+                                    <AccordionTrigger>
+                                        <div className="flex items-center gap-2">
+                                            <Cable className="h-4 w-4" />
+                                            <span>{t("hostsDialog.muxSettings")}</span>
+                                        </div>
+                                    </AccordionTrigger>
+                                    <AccordionContent className="px-2">
+                                        <div className="space-y-4">
+                                            <Tabs defaultValue="xray" className="w-full">
+                                                <TabsList className="grid grid-cols-3 mb-4">
+                                                    <TabsTrigger value="xray">Xray</TabsTrigger>
+                                                    <TabsTrigger value="sing_box">Sing-box</TabsTrigger>
+                                                    <TabsTrigger value="clash">Clash</TabsTrigger>
+                                                </TabsList>
+
+                                                {/* Xray Settings */}
+                                                <TabsContent dir={dir} value="xray">
+                                                    <div className="space-y-4">
+                                                        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                                            <FormField
+                                                                control={form.control}
+                                                                name="mux_settings.xray.concurrency"
+                                                                render={({ field }) => (
+                                                                    <FormItem>
+                                                                        <FormLabel>{t("hostsDialog.concurrency")}</FormLabel>
+                                                                        <FormControl>
+                                                                            <Input
+                                                                                type="number"
+                                                                                {...field}
+                                                                                value={field.value ?? ""}
+                                                                                onChange={e => field.onChange(e.target.value ? parseInt(e.target.value) : null)}
+                                                                            />
+                                                                        </FormControl>
+                                                                        <FormMessage />
+                                                                    </FormItem>
+                                                                )}
+                                                            />
+
+                                                            <FormField
+                                                                control={form.control}
+                                                                name="mux_settings.xray.xudp_concurrency"
+                                                                render={({ field }) => (
+                                                                    <FormItem>
+                                                                        <FormLabel>{t("hostsDialog.xudpConcurrency")}</FormLabel>
+                                                                        <FormControl>
+                                                                            <Input
+                                                                                type="number"
+                                                                                {...field}
+                                                                                value={field.value ?? ""}
+                                                                                onChange={e => field.onChange(e.target.value ? parseInt(e.target.value) : null)}
+                                                                            />
+                                                                        </FormControl>
+                                                                        <FormMessage />
+                                                                    </FormItem>
+                                                                )}
+                                                            />
+
+                                                            <FormField
+                                                                control={form.control}
+                                                                name="mux_settings.xray.xudp_proxy_443"
+                                                                render={() => (
+                                                                    <FormItem>
+                                                                        <FormLabel>{t("hostsDialog.xudpProxy443")}</FormLabel>
+                                                                        <Select
+                                                                            value={form.watch("mux_settings.xray.xudp_proxy_443") ?? "reject"}
+                                                                            onValueChange={(value) => {
+                                                                                form.setValue("mux_settings.xray.xudp_proxy_443", value);
+                                                                            }}
+                                                                        >
+                                                                            <SelectTrigger>
+                                                                                <SelectValue placeholder={t("host.xudp_proxy_443")} />
+                                                                            </SelectTrigger>
+                                                                            <SelectContent>
+                                                                                <SelectItem value="reject">{t("host.reject")}</SelectItem>
+                                                                                <SelectItem value="allow">{t("host.allow")}</SelectItem>
+                                                                                <SelectItem value="skip">{t("host.skip")}</SelectItem>
+                                                                            </SelectContent>
+                                                                        </Select>
+                                                                        <FormMessage />
+                                                                    </FormItem>
+                                                                )}
+                                                            />
+                                                        </div>
+                                                    </div>
+                                                </TabsContent>
+
+                                                {/* Sing-box Settings */}
+                                                <TabsContent dir={dir} value="sing_box">
+                                                    <div className="space-y-4">
+                                                        <FormField
+                                                            control={form.control}
+                                                            name="mux_settings.sing_box.protocol"
+                                                            render={({ field }) => (
+                                                                <FormItem>
+                                                                    <FormLabel>{t("hostsDialog.protocol")}</FormLabel>
+                                                                    <Select
+                                                                        onValueChange={(value) => field.onChange(value === "null" ? undefined : value)}
+                                                                        value={field.value ?? "null"}
+                                                                    >
+                                                                        <FormControl>
+                                                                            <SelectTrigger>
+                                                                                <SelectValue placeholder={t("hostsDialog.selectProtocol")} />
+                                                                            </SelectTrigger>
+                                                                        </FormControl>
+                                                                        <SelectContent>
+                                                                            <SelectItem value="none">{t("none")}</SelectItem>
+                                                                            <SelectItem value="h2mux">h2mux</SelectItem>
+                                                                            <SelectItem value="smux">smux</SelectItem>
+                                                                            <SelectItem value="yamux">yamux</SelectItem>
+                                                                        </SelectContent>
+                                                                    </Select>
+                                                                    <FormMessage />
+                                                                </FormItem>
+                                                            )}
+                                                        />
+
+                                                        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                                            <FormField
+                                                                control={form.control}
+                                                                name="mux_settings.sing_box.max_connections"
+                                                                render={({ field }) => (
+                                                                    <FormItem>
+                                                                        <FormLabel>{t("hostsDialog.maxConnections")}</FormLabel>
+                                                                        <FormControl>
+                                                                            <Input
+                                                                                type="number"
+                                                                                {...field}
+                                                                                value={field.value || ""}
+                                                                                onChange={e => field.onChange(e.target.value ? parseInt(e.target.value) : 0)}
+                                                                            />
+                                                                        </FormControl>
+                                                                        <FormMessage />
+                                                                    </FormItem>
+                                                                )}
+                                                            />
+
+                                                            <FormField
+                                                                control={form.control}
+                                                                name="mux_settings.sing_box.min_streams"
+                                                                render={({ field }) => (
+                                                                    <FormItem>
+                                                                        <FormLabel>{t("hostsDialog.minStreams")}</FormLabel>
+                                                                        <FormControl>
+                                                                            <Input
+                                                                                type="number"
+                                                                                {...field}
+                                                                                value={field.value || ""}
+                                                                                onChange={e => field.onChange(e.target.value ? parseInt(e.target.value) : 0)}
+                                                                            />
+                                                                        </FormControl>
+                                                                        <FormMessage />
+                                                                    </FormItem>
+                                                                )}
+                                                            />
+
+                                                            <FormField
+                                                                control={form.control}
+                                                                name="mux_settings.sing_box.max_streams"
+                                                                render={({ field }) => (
+                                                                    <FormItem>
+                                                                        <FormLabel>{t("hostsDialog.maxStreams")}</FormLabel>
+                                                                        <FormControl>
+                                                                            <Input
+                                                                                type="number"
+                                                                                {...field}
+                                                                                value={field.value || ""}
+                                                                                onChange={e => field.onChange(e.target.value ? parseInt(e.target.value) : 0)}
+                                                                            />
+                                                                        </FormControl>
+                                                                        <FormMessage />
+                                                                    </FormItem>
+                                                                )}
+                                                            />
                                                         </div>
 
-                                                        <div className="space-y-4 p-2">
-                                                            <h4 className="text-sm font-medium">{t("hostsDialog.tcp.response.title")}</h4>
+                                                        <div className="space-y-4">
+                                                            <h4 className="text-sm font-medium">{t("hostsDialog.brutal.title")}</h4>
                                                             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                                                                 <FormField
                                                                     control={form.control}
-                                                                    name="transport_settings.tcp_settings.response.version"
+                                                                    name="mux_settings.sing_box.brutal.up_mbps"
                                                                     render={({ field }) => (
                                                                         <FormItem>
-                                                                            <FormLabel>{t("hostsDialog.tcp.response.version")}</FormLabel>
-                                                                            <Select onValueChange={field.onChange} value={field.value}>
-                                                                                <FormControl>
-                                                                                    <SelectTrigger>
-                                                                                        <SelectValue />
-                                                                                    </SelectTrigger>
-                                                                                </FormControl>
-                                                                                <SelectContent>
-                                                                                    <SelectItem value="1.0">HTTP/1.0</SelectItem>
-                                                                                    <SelectItem value="1.1">HTTP/1.1</SelectItem>
-                                                                                    <SelectItem value="2.0">HTTP/2.0</SelectItem>
-                                                                                    <SelectItem value="3.0">HTTP/3.0</SelectItem>
-                                                                                </SelectContent>
-                                                                            </Select>
-                                                                            <FormMessage />
-                                                                        </FormItem>
-                                                                    )}
-                                                                />
-
-                                                                <FormField
-                                                                    control={form.control}
-                                                                    name="transport_settings.tcp_settings.response.status"
-                                                                    render={({ field }) => (
-                                                                        <FormItem>
-                                                                            <FormLabel>{t("hostsDialog.tcp.response.status")}</FormLabel>
+                                                                            <FormLabel>{t("hostsDialog.brutal.upMbps")}</FormLabel>
                                                                             <FormControl>
                                                                                 <Input
+                                                                                    type="number"
                                                                                     {...field}
-                                                                                    placeholder="200"
-                                                                                    pattern="[1-5]\d{2}"
+                                                                                    value={field.value || ""}
+                                                                                    onChange={e => field.onChange(e.target.value ? parseInt(e.target.value) : 0)}
                                                                                 />
                                                                             </FormControl>
                                                                             <FormMessage />
@@ -1819,542 +2223,79 @@ const HostModal: React.FC<HostModalProps> = ({
 
                                                                 <FormField
                                                                     control={form.control}
-                                                                    name="transport_settings.tcp_settings.response.reason"
+                                                                    name="mux_settings.sing_box.brutal.down_mbps"
                                                                     render={({ field }) => (
                                                                         <FormItem>
-                                                                            <FormLabel>{t("hostsDialog.tcp.response.reason")}</FormLabel>
-                                                                            <Select onValueChange={field.onChange} value={field.value || ""}>
-                                                                                <FormControl>
-                                                                                    <SelectTrigger>
-                                                                                        <SelectValue placeholder={t("hostsDialog.selectReason")} />
-                                                                                    </SelectTrigger>
-                                                                                </FormControl>
-                                                                                <SelectContent>
-                                                                                    {/* 1xx Information responses */}
-                                                                                    <SelectGroup>
-                                                                                        <SelectLabel>1xx Information</SelectLabel>
-                                                                                        <SelectItem value="Continue">{t("hostsDialog.httpReasons.100")}</SelectItem>
-                                                                                        <SelectItem value="Switching Protocols">{t("hostsDialog.httpReasons.101")}</SelectItem>
-                                                                                    </SelectGroup>
-
-                                                                                    {/* 2xx Success responses */}
-                                                                                    <SelectGroup>
-                                                                                        <SelectLabel>2xx Success</SelectLabel>
-                                                                                        <SelectItem value="OK">{t("hostsDialog.httpReasons.200")}</SelectItem>
-                                                                                        <SelectItem value="Created">{t("hostsDialog.httpReasons.201")}</SelectItem>
-                                                                                        <SelectItem value="Accepted">{t("hostsDialog.httpReasons.202")}</SelectItem>
-                                                                                        <SelectItem value="Non-Authoritative Information">{t("hostsDialog.httpReasons.203")}</SelectItem>
-                                                                                        <SelectItem value="No Content">{t("hostsDialog.httpReasons.204")}</SelectItem>
-                                                                                        <SelectItem value="Reset Content">{t("hostsDialog.httpReasons.205")}</SelectItem>
-                                                                                        <SelectItem value="Partial Content">{t("hostsDialog.httpReasons.206")}</SelectItem>
-                                                                                    </SelectGroup>
-
-                                                                                    {/* 3xx Redirection responses */}
-                                                                                    <SelectGroup>
-                                                                                        <SelectLabel>3xx Redirection</SelectLabel>
-                                                                                        <SelectItem value="Multiple Choices">{t("hostsDialog.httpReasons.300")}</SelectItem>
-                                                                                        <SelectItem value="Moved Permanently">{t("hostsDialog.httpReasons.301")}</SelectItem>
-                                                                                        <SelectItem value="Found">{t("hostsDialog.httpReasons.302")}</SelectItem>
-                                                                                        <SelectItem value="See Other">{t("hostsDialog.httpReasons.303")}</SelectItem>
-                                                                                        <SelectItem value="Not Modified">{t("hostsDialog.httpReasons.304")}</SelectItem>
-                                                                                        <SelectItem value="Use Proxy">{t("hostsDialog.httpReasons.305")}</SelectItem>
-                                                                                        <SelectItem value="Temporary Redirect">{t("hostsDialog.httpReasons.307")}</SelectItem>
-                                                                                        <SelectItem value="Permanent Redirect">{t("hostsDialog.httpReasons.308")}</SelectItem>
-                                                                                    </SelectGroup>
-
-                                                                                    {/* 4xx Client Error responses */}
-                                                                                    <SelectGroup>
-                                                                                        <SelectLabel>4xx Client Error</SelectLabel>
-                                                                                        <SelectItem value="Bad Request">{t("hostsDialog.httpReasons.400")}</SelectItem>
-                                                                                        <SelectItem value="Unauthorized">{t("hostsDialog.httpReasons.401")}</SelectItem>
-                                                                                        <SelectItem value="Payment Required">{t("hostsDialog.httpReasons.402")}</SelectItem>
-                                                                                        <SelectItem value="Forbidden">{t("hostsDialog.httpReasons.403")}</SelectItem>
-                                                                                        <SelectItem value="Not Found">{t("hostsDialog.httpReasons.404")}</SelectItem>
-                                                                                        <SelectItem value="Method Not Allowed">{t("hostsDialog.httpReasons.405")}</SelectItem>
-                                                                                        <SelectItem value="Not Acceptable">{t("hostsDialog.httpReasons.406")}</SelectItem>
-                                                                                        <SelectItem value="Proxy Authentication Required">{t("hostsDialog.httpReasons.407")}</SelectItem>
-                                                                                        <SelectItem value="Request Timeout">{t("hostsDialog.httpReasons.408")}</SelectItem>
-                                                                                        <SelectItem value="Conflict">{t("hostsDialog.httpReasons.409")}</SelectItem>
-                                                                                        <SelectItem value="Gone">{t("hostsDialog.httpReasons.410")}</SelectItem>
-                                                                                        <SelectItem value="Length Required">{t("hostsDialog.httpReasons.411")}</SelectItem>
-                                                                                        <SelectItem value="Precondition Failed">{t("hostsDialog.httpReasons.412")}</SelectItem>
-                                                                                        <SelectItem value="Payload Too Large">{t("hostsDialog.httpReasons.413")}</SelectItem>
-                                                                                        <SelectItem value="URI Too Long">{t("hostsDialog.httpReasons.414")}</SelectItem>
-                                                                                        <SelectItem value="Unsupported Media Type">{t("hostsDialog.httpReasons.415")}</SelectItem>
-                                                                                        <SelectItem value="Range Not Satisfiable">{t("hostsDialog.httpReasons.416")}</SelectItem>
-                                                                                        <SelectItem value="Expectation Failed">{t("hostsDialog.httpReasons.417")}</SelectItem>
-                                                                                        <SelectItem value="I'm a teapot">{t("hostsDialog.httpReasons.418")}</SelectItem>
-                                                                                        <SelectItem value="Misdirected Request">{t("hostsDialog.httpReasons.421")}</SelectItem>
-                                                                                        <SelectItem value="Unprocessable Entity">{t("hostsDialog.httpReasons.422")}</SelectItem>
-                                                                                        <SelectItem value="Locked">{t("hostsDialog.httpReasons.423")}</SelectItem>
-                                                                                        <SelectItem value="Failed Dependency">{t("hostsDialog.httpReasons.424")}</SelectItem>
-                                                                                        <SelectItem value="Too Early">{t("hostsDialog.httpReasons.425")}</SelectItem>
-                                                                                        <SelectItem value="Upgrade Required">{t("hostsDialog.httpReasons.426")}</SelectItem>
-                                                                                        <SelectItem value="Precondition Required">{t("hostsDialog.httpReasons.428")}</SelectItem>
-                                                                                        <SelectItem value="Too Many Requests">{t("hostsDialog.httpReasons.429")}</SelectItem>
-                                                                                        <SelectItem value="Request Header Fields Too Large">{t("hostsDialog.httpReasons.431")}</SelectItem>
-                                                                                        <SelectItem value="Unavailable For Legal Reasons">{t("hostsDialog.httpReasons.451")}</SelectItem>
-                                                                                    </SelectGroup>
-
-                                                                                    {/* 5xx Server Error responses */}
-                                                                                    <SelectGroup>
-                                                                                        <SelectLabel>5xx Server Error</SelectLabel>
-                                                                                        <SelectItem value="Internal Server Error">{t("hostsDialog.httpReasons.500")}</SelectItem>
-                                                                                        <SelectItem value="Not Implemented">{t("hostsDialog.httpReasons.501")}</SelectItem>
-                                                                                        <SelectItem value="Bad Gateway">{t("hostsDialog.httpReasons.502")}</SelectItem>
-                                                                                        <SelectItem value="Service Unavailable">{t("hostsDialog.httpReasons.503")}</SelectItem>
-                                                                                        <SelectItem value="Gateway Timeout">{t("hostsDialog.httpReasons.504")}</SelectItem>
-                                                                                        <SelectItem value="HTTP Version Not Supported">{t("hostsDialog.httpReasons.505")}</SelectItem>
-                                                                                    </SelectGroup>
-                                                                                </SelectContent>
-                                                                            </Select>
+                                                                            <FormLabel>{t("hostsDialog.brutal.downMbps")}</FormLabel>
+                                                                            <FormControl>
+                                                                                <Input
+                                                                                    type="number"
+                                                                                    {...field}
+                                                                                    value={field.value || ""}
+                                                                                    onChange={e => field.onChange(e.target.value ? parseInt(e.target.value) : 0)}
+                                                                                />
+                                                                            </FormControl>
                                                                             <FormMessage />
                                                                         </FormItem>
                                                                     )}
                                                                 />
                                                             </div>
-
-                                                            {/* Response Headers */}
-                                                            <div className="space-y-2">
-                                                                <div className="flex items-center justify-between">
-                                                                    <h4 className="text-sm font-medium">{t("hostsDialog.tcp.responseHeaders")}</h4>
-                                                                    <Button
-                                                                        type="button"
-                                                                        variant="outline"
-                                                                        size="icon"
-                                                                        className="h-6 w-6"
-                                                                        onClick={() => {
-                                                                            const currentHeaders = form.getValues("transport_settings.tcp_settings.response.headers") || {};
-                                                                            const newKey = `header_${Object.keys(currentHeaders).length}`;
-                                                                            form.setValue("transport_settings.tcp_settings.response.headers", {
-                                                                                ...currentHeaders,
-                                                                                [newKey]: [""]
-                                                                            }, {
-                                                                                shouldDirty: true,
-                                                                                shouldTouch: true
-                                                                            });
-                                                                        }}
-                                                                    >
-                                                                        <Plus className="h-4 w-4" />
-                                                                    </Button>
-                                                                </div>
-
-                                                                {/* Render response headers */}
-                                                                {Object.entries(form.watch("transport_settings.tcp_settings.response.headers") || {}).map(([key, values]) => (
-                                                                    <div key={key} className="grid grid-cols-[1fr,2fr,auto] gap-2">
-                                                                        <Input
-                                                                            placeholder={t("hostsDialog.tcp.headerName")}
-                                                                            defaultValue={key}
-                                                                            onBlur={(e) => {
-                                                                                if (e.target.value !== key) {
-                                                                                    const currentHeaders = { ...form.getValues("transport_settings.tcp_settings.response.headers") };
-                                                                                    const oldValues = currentHeaders[key];
-                                                                                    delete currentHeaders[key];
-                                                                                    currentHeaders[e.target.value] = oldValues;
-                                                                                    form.setValue("transport_settings.tcp_settings.response.headers", currentHeaders, {
-                                                                                        shouldDirty: true,
-                                                                                        shouldTouch: true
-                                                                                    });
-                                                                                }
-                                                                            }}
-                                                                        />
-                                                                        <Input
-                                                                            placeholder={t("hostsDialog.tcp.headerValue")}
-                                                                            value={values.join(", ")}
-                                                                            onChange={(e) => {
-                                                                                const currentHeaders = { ...form.getValues("transport_settings.tcp_settings.response.headers") };
-                                                                                currentHeaders[key] = e.target.value.split(",").map(v => v.trim());
-                                                                                form.setValue("transport_settings.tcp_settings.response.headers", currentHeaders, {
-                                                                                    shouldDirty: true,
-                                                                                    shouldTouch: true
-                                                                                });
-                                                                            }}
-                                                                        />
-                                                                        <Button
-                                                                            type="button"
-                                                                            variant="ghost"
-                                                                            size="icon"
-                                                                            onClick={() => {
-                                                                                const currentHeaders = { ...form.getValues("transport_settings.tcp_settings.response.headers") };
-                                                                                delete currentHeaders[key];
-                                                                                form.setValue("transport_settings.tcp_settings.response.headers", currentHeaders, {
-                                                                                    shouldDirty: true,
-                                                                                    shouldTouch: true
-                                                                                });
-                                                                            }}
-                                                                        >
-                                                                            <Trash2 className="h-4 w-4 text-red-500" />
-                                                                        </Button>
-                                                                    </div>
-                                                                ))}
-                                                            </div>
                                                         </div>
-                                                    </>
-                                                )}
-                                            </TabsContent>
 
-                                            {/* WebSocket Settings */}
-                                            <TabsContent dir={dir} value="websocket" className="space-y-4">
-                                                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                                    <FormField
-                                                        control={form.control}
-                                                        name="transport_settings.websocket_settings.heartbeatPeriod"
-                                                        render={({ field }) => (
-                                                            <FormItem>
-                                                                <FormLabel>{t("hostsDialog.websocket.heartbeatPeriod")}</FormLabel>
-                                                                <FormControl>
-                                                                    <Input
-                                                                        type="number"
-                                                                        {...field}
-                                                                        onChange={(e) => field.onChange(e.target.value ? Number(e.target.value) : 0)}
-                                                                        value={field.value}
-                                                                    />
-                                                                </FormControl>
-                                                                <FormMessage />
-                                                            </FormItem>
-                                                        )}
-                                                    />
-                                                </div>
-                                            </TabsContent>
-                                        </Tabs>
-                                    </div>
-                                </AccordionContent>
-                            </AccordionItem>
-
-                            <AccordionItem className="border px-4 rounded-sm [&_[data-state=open]]:no-underline [&_[data-state=closed]]:no-underline" value="mux">
-                                <AccordionTrigger>
-                                    <div className="flex items-center gap-2">
-                                        <Cable className="h-4 w-4" />
-                                        <span>{t("hostsDialog.muxSettings")}</span>
-                                    </div>
-                                </AccordionTrigger>
-                                <AccordionContent className="px-2">
-                                    <div className="space-y-4">
-                                        <Tabs defaultValue="xray" className="w-full">
-                                            <TabsList className="grid grid-cols-3 mb-4">
-                                                <TabsTrigger value="xray">Xray</TabsTrigger>
-                                                <TabsTrigger value="sing_box">Sing-box</TabsTrigger>
-                                                <TabsTrigger value="clash">Clash</TabsTrigger>
-                                            </TabsList>
-
-                                            {/* Xray Settings */}
-                                            <TabsContent dir={dir} value="xray">
-                                                <div className="space-y-4">
-                                                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                                                         <FormField
                                                             control={form.control}
-                                                            name="mux_settings.xray.concurrency"
+                                                            name="mux_settings.sing_box.padding"
                                                             render={({ field }) => (
-                                                                <FormItem>
-                                                                    <FormLabel>{t("hostsDialog.concurrency")}</FormLabel>
+                                                                <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
+                                                                    <div className="space-y-0.5">
+                                                                        <FormLabel className="text-base">{t("hostsDialog.padding")}</FormLabel>
+                                                                    </div>
                                                                     <FormControl>
-                                                                        <Input
-                                                                            type="number"
-                                                                            {...field}
-                                                                            value={field.value ?? ""}
-                                                                            onChange={e => field.onChange(e.target.value ? parseInt(e.target.value) : null)}
-                                                                        />
+                                                                        <Switch checked={field.value || false} onCheckedChange={field.onChange} />
                                                                     </FormControl>
-                                                                    <FormMessage />
                                                                 </FormItem>
                                                             )}
                                                         />
+                                                    </div>
+                                                </TabsContent>
 
+                                                {/* Clash Settings */}
+                                                <TabsContent dir={dir} value="clash">
+                                                    <div className="space-y-4">
                                                         <FormField
                                                             control={form.control}
-                                                            name="mux_settings.xray.xudp_concurrency"
+                                                            name="mux_settings.clash.protocol"
                                                             render={({ field }) => (
                                                                 <FormItem>
-                                                                    <FormLabel>{t("hostsDialog.xudpConcurrency")}</FormLabel>
-                                                                    <FormControl>
-                                                                        <Input
-                                                                            type="number"
-                                                                            {...field}
-                                                                            value={field.value ?? ""}
-                                                                            onChange={e => field.onChange(e.target.value ? parseInt(e.target.value) : null)}
-                                                                        />
-                                                                    </FormControl>
-                                                                    <FormMessage />
-                                                                </FormItem>
-                                                            )}
-                                                        />
-
-                                                        <FormField
-                                                            control={form.control}
-                                                            name="mux_settings.xray.xudp_proxy_443"
-                                                            render={() => (
-                                                                <FormItem>
-                                                                    <FormLabel>{t("hostsDialog.xudpProxy443")}</FormLabel>
+                                                                    <FormLabel>{t("hostsDialog.protocol")}</FormLabel>
                                                                     <Select
-                                                                        value={form.watch("mux_settings.xray.xudp_proxy_443") ?? "reject"}
-                                                                        onValueChange={(value) => {
-                                                                            form.setValue("mux_settings.xray.xudp_proxy_443", value);
-                                                                        }}
+                                                                        onValueChange={(value) => field.onChange(value === "null" ? undefined : value)}
+                                                                        value={field.value ?? "null"}
                                                                     >
-                                                                        <SelectTrigger>
-                                                                            <SelectValue placeholder={t("host.xudp_proxy_443")} />
-                                                                        </SelectTrigger>
+                                                                        <FormControl>
+                                                                            <SelectTrigger>
+                                                                                <SelectValue placeholder={t("hostsDialog.selectProtocol")} />
+                                                                            </SelectTrigger>
+                                                                        </FormControl>
                                                                         <SelectContent>
-                                                                            <SelectItem value="reject">{t("host.reject")}</SelectItem>
-                                                                            <SelectItem value="allow">{t("host.allow")}</SelectItem>
-                                                                            <SelectItem value="skip">{t("host.skip")}</SelectItem>
+                                                                            <SelectItem value="none">{t("none")}</SelectItem>
+                                                                            <SelectItem value="smux">smux</SelectItem>
+                                                                            <SelectItem value="yamux">yamux</SelectItem>
+                                                                            <SelectItem value="h2mux">h2mux</SelectItem>
                                                                         </SelectContent>
                                                                     </Select>
                                                                     <FormMessage />
                                                                 </FormItem>
                                                             )}
                                                         />
-                                                    </div>
-                                                </div>
-                                            </TabsContent>
 
-                                            {/* Sing-box Settings */}
-                                            <TabsContent dir={dir} value="sing_box">
-                                                <div className="space-y-4">
-                                                    <FormField
-                                                        control={form.control}
-                                                        name="mux_settings.sing_box.protocol"
-                                                        render={({ field }) => (
-                                                            <FormItem>
-                                                                <FormLabel>{t("hostsDialog.protocol")}</FormLabel>
-                                                                <Select
-                                                                    onValueChange={(value) => field.onChange(value === "null" ? undefined : value)}
-                                                                    value={field.value ?? "null"}
-                                                                >
-                                                                    <FormControl>
-                                                                        <SelectTrigger>
-                                                                            <SelectValue placeholder={t("hostsDialog.selectProtocol")} />
-                                                                        </SelectTrigger>
-                                                                    </FormControl>
-                                                                    <SelectContent>
-                                                                        <SelectItem value="none">{t("none")}</SelectItem>
-                                                                        <SelectItem value="h2mux">h2mux</SelectItem>
-                                                                        <SelectItem value="smux">smux</SelectItem>
-                                                                        <SelectItem value="yamux">yamux</SelectItem>
-                                                                    </SelectContent>
-                                                                </Select>
-                                                                <FormMessage />
-                                                            </FormItem>
-                                                        )}
-                                                    />
-
-                                                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                                        <FormField
-                                                            control={form.control}
-                                                            name="mux_settings.sing_box.max_connections"
-                                                            render={({ field }) => (
-                                                                <FormItem>
-                                                                    <FormLabel>{t("hostsDialog.maxConnections")}</FormLabel>
-                                                                    <FormControl>
-                                                                        <Input
-                                                                            type="number"
-                                                                            {...field}
-                                                                            value={field.value || ""}
-                                                                            onChange={e => field.onChange(e.target.value ? parseInt(e.target.value) : 0)}
-                                                                        />
-                                                                    </FormControl>
-                                                                    <FormMessage />
-                                                                </FormItem>
-                                                            )}
-                                                        />
-
-                                                        <FormField
-                                                            control={form.control}
-                                                            name="mux_settings.sing_box.min_streams"
-                                                            render={({ field }) => (
-                                                                <FormItem>
-                                                                    <FormLabel>{t("hostsDialog.minStreams")}</FormLabel>
-                                                                    <FormControl>
-                                                                        <Input
-                                                                            type="number"
-                                                                            {...field}
-                                                                            value={field.value || ""}
-                                                                            onChange={e => field.onChange(e.target.value ? parseInt(e.target.value) : 0)}
-                                                                        />
-                                                                    </FormControl>
-                                                                    <FormMessage />
-                                                                </FormItem>
-                                                            )}
-                                                        />
-
-                                                        <FormField
-                                                            control={form.control}
-                                                            name="mux_settings.sing_box.max_streams"
-                                                            render={({ field }) => (
-                                                                <FormItem>
-                                                                    <FormLabel>{t("hostsDialog.maxStreams")}</FormLabel>
-                                                                    <FormControl>
-                                                                        <Input
-                                                                            type="number"
-                                                                            {...field}
-                                                                            value={field.value || ""}
-                                                                            onChange={e => field.onChange(e.target.value ? parseInt(e.target.value) : 0)}
-                                                                        />
-                                                                    </FormControl>
-                                                                    <FormMessage />
-                                                                </FormItem>
-                                                            )}
-                                                        />
-                                                    </div>
-
-                                                    <div className="space-y-4">
-                                                        <h4 className="text-sm font-medium">{t("hostsDialog.brutal.title")}</h4>
                                                         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                                                             <FormField
                                                                 control={form.control}
-                                                                name="mux_settings.sing_box.brutal.up_mbps"
+                                                                name="mux_settings.clash.max_connections"
                                                                 render={({ field }) => (
                                                                     <FormItem>
-                                                                        <FormLabel>{t("hostsDialog.brutal.upMbps")}</FormLabel>
-                                                                        <FormControl>
-                                                                            <Input
-                                                                                type="number"
-                                                                                {...field}
-                                                                                value={field.value || ""}
-                                                                                onChange={e => field.onChange(e.target.value ? parseInt(e.target.value) : 0)}
-                                                                            />
-                                                                        </FormControl>
-                                                                        <FormMessage />
-                                                                    </FormItem>
-                                                                )}
-                                                            />
-
-                                                            <FormField
-                                                                control={form.control}
-                                                                name="mux_settings.sing_box.brutal.down_mbps"
-                                                                render={({ field }) => (
-                                                                    <FormItem>
-                                                                        <FormLabel>{t("hostsDialog.brutal.downMbps")}</FormLabel>
-                                                                        <FormControl>
-                                                                            <Input
-                                                                                type="number"
-                                                                                {...field}
-                                                                                value={field.value || ""}
-                                                                                onChange={e => field.onChange(e.target.value ? parseInt(e.target.value) : 0)}
-                                                                            />
-                                                                        </FormControl>
-                                                                        <FormMessage />
-                                                                    </FormItem>
-                                                                )}
-                                                            />
-                                                        </div>
-                                                    </div>
-
-                                                    <FormField
-                                                        control={form.control}
-                                                        name="mux_settings.sing_box.padding"
-                                                        render={({ field }) => (
-                                                            <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
-                                                                <div className="space-y-0.5">
-                                                                    <FormLabel className="text-base">{t("hostsDialog.padding")}</FormLabel>
-                                                                </div>
-                                                                <FormControl>
-                                                                    <Switch checked={field.value || false} onCheckedChange={field.onChange} />
-                                                                </FormControl>
-                                                            </FormItem>
-                                                        )}
-                                                    />
-                                                </div>
-                                            </TabsContent>
-
-                                            {/* Clash Settings */}
-                                            <TabsContent dir={dir} value="clash">
-                                                <div className="space-y-4">
-                                                    <FormField
-                                                        control={form.control}
-                                                        name="mux_settings.clash.protocol"
-                                                        render={({ field }) => (
-                                                            <FormItem>
-                                                                <FormLabel>{t("hostsDialog.protocol")}</FormLabel>
-                                                                <Select
-                                                                    onValueChange={(value) => field.onChange(value === "null" ? undefined : value)}
-                                                                    value={field.value ?? "null"}
-                                                                >
-                                                                    <FormControl>
-                                                                        <SelectTrigger>
-                                                                            <SelectValue placeholder={t("hostsDialog.selectProtocol")} />
-                                                                        </SelectTrigger>
-                                                                    </FormControl>
-                                                                    <SelectContent>
-                                                                        <SelectItem value="none">{t("none")}</SelectItem>
-                                                                        <SelectItem value="smux">smux</SelectItem>
-                                                                        <SelectItem value="yamux">yamux</SelectItem>
-                                                                        <SelectItem value="h2mux">h2mux</SelectItem>
-                                                                    </SelectContent>
-                                                                </Select>
-                                                                <FormMessage />
-                                                            </FormItem>
-                                                        )}
-                                                    />
-
-                                                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                                        <FormField
-                                                            control={form.control}
-                                                            name="mux_settings.clash.max_connections"
-                                                            render={({ field }) => (
-                                                                <FormItem>
-                                                                    <FormLabel>{t("hostsDialog.maxConnections")}</FormLabel>
-                                                                    <FormControl>
-                                                                        <Input
-                                                                            type="number"
-                                                                            {...field}
-                                                                            value={field.value ?? ""}
-                                                                            onChange={e => field.onChange(e.target.value ? parseInt(e.target.value) : null)}
-                                                                        />
-                                                                    </FormControl>
-                                                                    <FormMessage />
-                                                                </FormItem>
-                                                            )}
-                                                        />
-
-                                                        <FormField
-                                                            control={form.control}
-                                                            name="mux_settings.clash.min_streams"
-                                                            render={({ field }) => (
-                                                                <FormItem>
-                                                                    <FormLabel>{t("hostsDialog.minStreams")}</FormLabel>
-                                                                    <FormControl>
-                                                                        <Input
-                                                                            type="number"
-                                                                            {...field}
-                                                                            value={field.value ?? ""}
-                                                                            onChange={e => field.onChange(e.target.value ? parseInt(e.target.value) : null)}
-                                                                        />
-                                                                    </FormControl>
-                                                                    <FormMessage />
-                                                                </FormItem>
-                                                            )}
-                                                        />
-
-                                                        <FormField
-                                                            control={form.control}
-                                                            name="mux_settings.clash.max_streams"
-                                                            render={({ field }) => (
-                                                                <FormItem>
-                                                                    <FormLabel>{t("hostsDialog.maxStreams")}</FormLabel>
-                                                                    <FormControl>
-                                                                        <Input
-                                                                            type="number"
-                                                                            {...field}
-                                                                            value={field.value ?? ""}
-                                                                            onChange={e => field.onChange(e.target.value ? parseInt(e.target.value) : null)}
-                                                                        />
-                                                                    </FormControl>
-                                                                    <FormMessage />
-                                                                </FormItem>
-                                                            )}
-                                                        />
-                                                    </div>
-
-                                                    <div className="space-y-4">
-                                                        <h4 className="text-sm font-medium">{t("hostsDialog.brutal.title")}</h4>
-                                                        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                                                            <FormField
-                                                                control={form.control}
-                                                                name="mux_settings.clash.brutal.up_mbps"
-                                                                render={({ field }) => (
-                                                                    <FormItem>
-                                                                        <FormLabel>{t("hostsDialog.brutal.upMbps")}</FormLabel>
+                                                                        <FormLabel>{t("hostsDialog.maxConnections")}</FormLabel>
                                                                         <FormControl>
                                                                             <Input
                                                                                 type="number"
@@ -2370,10 +2311,29 @@ const HostModal: React.FC<HostModalProps> = ({
 
                                                             <FormField
                                                                 control={form.control}
-                                                                name="mux_settings.clash.brutal.down_mbps"
+                                                                name="mux_settings.clash.min_streams"
                                                                 render={({ field }) => (
                                                                     <FormItem>
-                                                                        <FormLabel>{t("hostsDialog.brutal.downMbps")}</FormLabel>
+                                                                        <FormLabel>{t("hostsDialog.minStreams")}</FormLabel>
+                                                                        <FormControl>
+                                                                            <Input
+                                                                                type="number"
+                                                                                {...field}
+                                                                                value={field.value ?? ""}
+                                                                                onChange={e => field.onChange(e.target.value ? parseInt(e.target.value) : null)}
+                                                                            />
+                                                                        </FormControl>
+                                                                        <FormMessage />
+                                                                    </FormItem>
+                                                                )}
+                                                            />
+
+                                                            <FormField
+                                                                control={form.control}
+                                                                name="mux_settings.clash.max_streams"
+                                                                render={({ field }) => (
+                                                                    <FormItem>
+                                                                        <FormLabel>{t("hostsDialog.maxStreams")}</FormLabel>
                                                                         <FormControl>
                                                                             <Input
                                                                                 type="number"
@@ -2387,69 +2347,113 @@ const HostModal: React.FC<HostModalProps> = ({
                                                                 )}
                                                             />
                                                         </div>
+
+                                                        <div className="space-y-4">
+                                                            <h4 className="text-sm font-medium">{t("hostsDialog.brutal.title")}</h4>
+                                                            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                                                <FormField
+                                                                    control={form.control}
+                                                                    name="mux_settings.clash.brutal.up_mbps"
+                                                                    render={({ field }) => (
+                                                                        <FormItem>
+                                                                            <FormLabel>{t("hostsDialog.brutal.upMbps")}</FormLabel>
+                                                                            <FormControl>
+                                                                                <Input
+                                                                                    type="number"
+                                                                                    {...field}
+                                                                                    value={field.value ?? ""}
+                                                                                    onChange={e => field.onChange(e.target.value ? parseInt(e.target.value) : null)}
+                                                                                />
+                                                                            </FormControl>
+                                                                            <FormMessage />
+                                                                        </FormItem>
+                                                                    )}
+                                                                />
+
+                                                                <FormField
+                                                                    control={form.control}
+                                                                    name="mux_settings.clash.brutal.down_mbps"
+                                                                    render={({ field }) => (
+                                                                        <FormItem>
+                                                                            <FormLabel>{t("hostsDialog.brutal.downMbps")}</FormLabel>
+                                                                            <FormControl>
+                                                                                <Input
+                                                                                    type="number"
+                                                                                    {...field}
+                                                                                    value={field.value ?? ""}
+                                                                                    onChange={e => field.onChange(e.target.value ? parseInt(e.target.value) : null)}
+                                                                                />
+                                                                            </FormControl>
+                                                                            <FormMessage />
+                                                                        </FormItem>
+                                                                    )}
+                                                                />
+                                                            </div>
+                                                        </div>
+
+                                                        <FormField
+                                                            control={form.control}
+                                                            name="mux_settings.clash.padding"
+                                                            render={({ field }) => (
+                                                                <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
+                                                                    <div className="space-y-0.5">
+                                                                        <FormLabel className="text-base">{t("hostsDialog.padding")}</FormLabel>
+                                                                    </div>
+                                                                    <FormControl>
+                                                                        <Switch
+                                                                            checked={field.value ?? false}
+                                                                            onCheckedChange={field.onChange}
+                                                                        />
+                                                                    </FormControl>
+                                                                </FormItem>
+                                                            )}
+                                                        />
+
+                                                        <FormField
+                                                            control={form.control}
+                                                            name="mux_settings.clash.statistic"
+                                                            render={({ field }) => (
+                                                                <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
+                                                                    <div className="space-y-0.5">
+                                                                        <FormLabel className="text-base">{t("hostsDialog.statistic")}</FormLabel>
+                                                                    </div>
+                                                                    <FormControl>
+                                                                        <Switch
+                                                                            checked={field.value ?? false}
+                                                                            onCheckedChange={field.onChange}
+                                                                        />
+                                                                    </FormControl>
+                                                                </FormItem>
+                                                            )}
+                                                        />
+
+                                                        <FormField
+                                                            control={form.control}
+                                                            name="mux_settings.clash.only_tcp"
+                                                            render={({ field }) => (
+                                                                <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
+                                                                    <div className="space-y-0.5">
+                                                                        <FormLabel className="text-base">{t("hostsDialog.onlyTcp")}</FormLabel>
+                                                                    </div>
+                                                                    <FormControl>
+                                                                        <Switch
+                                                                            checked={field.value ?? false}
+                                                                            onCheckedChange={field.onChange}
+                                                                        />
+                                                                    </FormControl>
+                                                                </FormItem>
+                                                            )}
+                                                        />
                                                     </div>
+                                                </TabsContent>
+                                            </Tabs>
+                                        </div>
+                                    </AccordionContent>
+                                </AccordionItem>
+                            </Accordion>
 
-                                                    <FormField
-                                                        control={form.control}
-                                                        name="mux_settings.clash.padding"
-                                                        render={({ field }) => (
-                                                            <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
-                                                                <div className="space-y-0.5">
-                                                                    <FormLabel className="text-base">{t("hostsDialog.padding")}</FormLabel>
-                                                                </div>
-                                                                <FormControl>
-                                                                    <Switch
-                                                                        checked={field.value ?? false}
-                                                                        onCheckedChange={field.onChange}
-                                                                    />
-                                                                </FormControl>
-                                                            </FormItem>
-                                                        )}
-                                                    />
 
-                                                    <FormField
-                                                        control={form.control}
-                                                        name="mux_settings.clash.statistic"
-                                                        render={({ field }) => (
-                                                            <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
-                                                                <div className="space-y-0.5">
-                                                                    <FormLabel className="text-base">{t("hostsDialog.statistic")}</FormLabel>
-                                                                </div>
-                                                                <FormControl>
-                                                                    <Switch
-                                                                        checked={field.value ?? false}
-                                                                        onCheckedChange={field.onChange}
-                                                                    />
-                                                                </FormControl>
-                                                            </FormItem>
-                                                        )}
-                                                    />
-
-                                                    <FormField
-                                                        control={form.control}
-                                                        name="mux_settings.clash.only_tcp"
-                                                        render={({ field }) => (
-                                                            <FormItem className="flex flex-row items-center justify-between rounded-lg border p-4">
-                                                                <div className="space-y-0.5">
-                                                                    <FormLabel className="text-base">{t("hostsDialog.onlyTcp")}</FormLabel>
-                                                                </div>
-                                                                <FormControl>
-                                                                    <Switch
-                                                                        checked={field.value ?? false}
-                                                                        onCheckedChange={field.onChange}
-                                                                    />
-                                                                </FormControl>
-                                                            </FormItem>
-                                                        )}
-                                                    />
-                                                </div>
-                                            </TabsContent>
-                                        </Tabs>
-                                    </div>
-                                </AccordionContent>
-                            </AccordionItem>
-                        </Accordion>
-
+                        </div>
                         <div className="flex justify-end gap-2">
                             <Button type="button" variant="outline" onClick={() => handleModalOpenChange(false)}>
                                 {t("cancel")}

--- a/dashboard/src/components/dialogs/NodeModal.tsx
+++ b/dashboard/src/components/dialogs/NodeModal.tsx
@@ -1,9 +1,9 @@
-import {Dialog, DialogContent, DialogHeader, DialogTitle} from '@/components/ui/dialog'
-import {Form, FormControl, FormField, FormItem, FormLabel, FormMessage} from '@/components/ui/form'
-import {Input} from '@/components/ui/input'
-import {Button} from '@/components/ui/button'
-import {useTranslation} from 'react-i18next'
-import {UseFormReturn} from 'react-hook-form'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { useTranslation } from 'react-i18next'
+import { UseFormReturn } from 'react-hook-form'
 import {
     useCreateNode,
     useModifyNode,
@@ -13,16 +13,16 @@ import {
     getNode,
     reconnectNode
 } from '@/service/api'
-import {toast} from '@/hooks/use-toast'
-import {z} from 'zod'
-import {cn} from '@/lib/utils'
-import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from '@/components/ui/select'
-import {Textarea} from '@/components/ui/textarea'
-import {queryClient} from '@/utils/query-client'
+import { toast } from '@/hooks/use-toast'
+import { z } from 'zod'
+import { cn } from '@/lib/utils'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { Textarea } from '@/components/ui/textarea'
+import { queryClient } from '@/utils/query-client'
 import useDirDetection from '@/hooks/use-dir-detection'
-import {useState, useEffect} from 'react'
-import {Loader2} from 'lucide-react'
-import {v4 as uuidv4, v5 as uuidv5, v6 as uuidv6, v7 as uuidv7} from 'uuid'
+import { useState, useEffect } from 'react'
+import { Loader2 } from 'lucide-react'
+import { v4 as uuidv4, v5 as uuidv5, v6 as uuidv6, v7 as uuidv7 } from 'uuid'
 
 export const nodeFormSchema = z.object({
     name: z.string().min(1, 'Name is required'),
@@ -50,12 +50,12 @@ interface NodeModalProps {
 
 type ConnectionStatus = 'idle' | 'success' | 'error' | 'checking';
 
-export default function NodeModal({isDialogOpen, onOpenChange, form, editingNode, editingNodeId}: NodeModalProps) {
-    const {t} = useTranslation()
+export default function NodeModal({ isDialogOpen, onOpenChange, form, editingNode, editingNodeId }: NodeModalProps) {
+    const { t } = useTranslation()
     const dir = useDirDetection()
     const addNodeMutation = useCreateNode()
     const modifyNodeMutation = useModifyNode()
-    const {data: cores} = useGetAllCores()
+    const { data: cores } = useGetAllCores()
     const [statusChecking, setStatusChecking] = useState(false)
     const [connectionStatus, setConnectionStatus] = useState<ConnectionStatus>('idle')
     const [errorDetails, setErrorDetails] = useState<string | null>(null)
@@ -87,7 +87,7 @@ export default function NodeModal({isDialogOpen, onOpenChange, form, editingNode
     useEffect(() => {
         if (!isDialogOpen || !autoCheck || editingNode || !debouncedValues) return
 
-        const {name, address, port, api_key} = debouncedValues
+        const { name, address, port, api_key } = debouncedValues
         if (name && address && port && api_key) {
             checkNodeStatus()
         }
@@ -214,7 +214,7 @@ export default function NodeModal({isDialogOpen, onOpenChange, form, editingNode
                 })
                 nodeId = editingNodeId;
                 toast({
-                    title: t('success', {defaultValue: 'Success'}),
+                    title: t('success', { defaultValue: 'Success' }),
                     description: t('nodes.editSuccess', {
                         name: values.name,
                         defaultValue: 'Node «{name}» has been updated successfully'
@@ -226,7 +226,7 @@ export default function NodeModal({isDialogOpen, onOpenChange, form, editingNode
                 })
                 nodeId = result?.id;
                 toast({
-                    title: t('success', {defaultValue: 'Success'}),
+                    title: t('success', { defaultValue: 'Success' }),
                     description: t('nodes.createSuccess', {
                         name: values.name,
                         defaultValue: 'Node «{name}» has been created successfully'
@@ -254,13 +254,13 @@ export default function NodeModal({isDialogOpen, onOpenChange, form, editingNode
             }
 
             // Invalidate nodes queries after successful operation
-            queryClient.invalidateQueries({queryKey: ['/api/nodes']})
+            queryClient.invalidateQueries({ queryKey: ['/api/nodes'] })
             onOpenChange(false)
             form.reset()
         } catch (error: any) {
             console.error('Node operation failed:', error)
             toast({
-                title: t('error', {defaultValue: 'Error'}),
+                title: t('error', { defaultValue: 'Error' }),
                 description: t(editingNode ? 'nodes.editFailed' : 'nodes.createFailed', {
                     name: values.name,
                     error: error?.message || '',
@@ -293,13 +293,13 @@ export default function NodeModal({isDialogOpen, onOpenChange, form, editingNode
                                         connectionStatus === 'error' ? 'bg-red-500 dark:bg-red-400' :
                                             connectionStatus === 'checking' ? 'bg-yellow-500 dark:bg-yellow-400' :
                                                 'bg-gray-500 dark:bg-gray-400'
-                                    }`}/>
+                                        }`} />
                                 <span className="text-sm font-medium text-foreground">
-                  {connectionStatus === 'success' ? t('nodeModal.status.connected') :
-                      connectionStatus === 'error' ? t('nodeModal.status.error') :
-                          connectionStatus === 'checking' ? t('nodeModal.status.connecting') :
-                              t('nodeModal.status.disabled')}
-                </span>
+                                    {connectionStatus === 'success' ? t('nodeModal.status.connected') :
+                                        connectionStatus === 'error' ? t('nodeModal.status.error') :
+                                            connectionStatus === 'checking' ? t('nodeModal.status.connecting') :
+                                                t('nodeModal.status.disabled')}
+                                </span>
                             </div>
                             {connectionStatus === 'error' && (
                                 <Button
@@ -333,7 +333,7 @@ export default function NodeModal({isDialogOpen, onOpenChange, form, editingNode
                                 >
                                     {reconnecting ? (
                                         <div className="flex items-center gap-1">
-                                            <Loader2 className="h-3 w-3 animate-spin"/>
+                                            <Loader2 className="h-3 w-3 animate-spin" />
                                             {t('nodeModal.reconnecting')}
                                         </div>
                                     ) : (
@@ -350,7 +350,7 @@ export default function NodeModal({isDialogOpen, onOpenChange, form, editingNode
                             >
                                 {statusChecking ? (
                                     <div className="flex items-center gap-1">
-                                        <Loader2 className="h-3 w-3 animate-spin"/>
+                                        <Loader2 className="h-3 w-3 animate-spin" />
                                         {t('nodeModal.statusChecking')}
                                     </div>
                                 ) : (
@@ -376,13 +376,13 @@ export default function NodeModal({isDialogOpen, onOpenChange, form, editingNode
                                     <FormField
                                         control={form.control}
                                         name="name"
-                                        render={({field}) => (
+                                        render={({ field }) => (
                                             <FormItem>
                                                 <FormLabel>{t('nodeModal.name')}</FormLabel>
                                                 <FormControl>
                                                     <Input placeholder={t('nodeModal.namePlaceholder')} {...field} />
                                                 </FormControl>
-                                                <FormMessage/>
+                                                <FormMessage />
                                             </FormItem>
                                         )}
                                     />
@@ -391,14 +391,14 @@ export default function NodeModal({isDialogOpen, onOpenChange, form, editingNode
                                         <FormField
                                             control={form.control}
                                             name="address"
-                                            render={({field}) => (
+                                            render={({ field }) => (
                                                 <FormItem>
                                                     <FormLabel>{t('nodeModal.address')}</FormLabel>
                                                     <FormControl>
                                                         <Input
                                                             placeholder={t('nodeModal.addressPlaceholder')} {...field} />
                                                     </FormControl>
-                                                    <FormMessage/>
+                                                    <FormMessage />
                                                 </FormItem>
                                             )}
                                         />
@@ -406,7 +406,7 @@ export default function NodeModal({isDialogOpen, onOpenChange, form, editingNode
                                         <FormField
                                             control={form.control}
                                             name="port"
-                                            render={({field}) => (
+                                            render={({ field }) => (
                                                 <FormItem>
                                                     <FormLabel>{t('nodeModal.port')}</FormLabel>
                                                     <FormControl>
@@ -417,7 +417,7 @@ export default function NodeModal({isDialogOpen, onOpenChange, form, editingNode
                                                             onChange={(e) => field.onChange(parseInt(e.target.value))}
                                                         />
                                                     </FormControl>
-                                                    <FormMessage/>
+                                                    <FormMessage />
                                                 </FormItem>
                                             )}
                                         />
@@ -426,7 +426,7 @@ export default function NodeModal({isDialogOpen, onOpenChange, form, editingNode
                                     <FormField
                                         control={form.control}
                                         name="core_config_id"
-                                        render={({field}) => (
+                                        render={({ field }) => (
                                             <FormItem>
                                                 <FormLabel>{t('nodeModal.coreConfig')}</FormLabel>
                                                 <Select
@@ -436,7 +436,7 @@ export default function NodeModal({isDialogOpen, onOpenChange, form, editingNode
                                                 >
                                                     <FormControl>
                                                         <SelectTrigger>
-                                                            <SelectValue placeholder={t('nodeModal.selectCoreConfig')}/>
+                                                            <SelectValue placeholder={t('nodeModal.selectCoreConfig')} />
                                                         </SelectTrigger>
                                                     </FormControl>
                                                     <SelectContent>
@@ -447,7 +447,7 @@ export default function NodeModal({isDialogOpen, onOpenChange, form, editingNode
                                                         ))}
                                                     </SelectContent>
                                                 </Select>
-                                                <FormMessage/>
+                                                <FormMessage />
                                             </FormItem>
                                         )}
                                     />
@@ -457,7 +457,7 @@ export default function NodeModal({isDialogOpen, onOpenChange, form, editingNode
                                             <FormField
                                                 control={form.control}
                                                 name="usage_coefficient"
-                                                render={({field}) => (
+                                                render={({ field }) => (
                                                     <FormItem className='flex-1'>
                                                         <FormLabel>{t('nodeModal.usageRatio')}</FormLabel>
                                                         <FormControl>
@@ -469,7 +469,7 @@ export default function NodeModal({isDialogOpen, onOpenChange, form, editingNode
                                                                 onChange={(e) => field.onChange(parseFloat(e.target.value))}
                                                             />
                                                         </FormControl>
-                                                        <FormMessage/>
+                                                        <FormMessage />
                                                     </FormItem>
                                                 )}
                                             />
@@ -477,7 +477,7 @@ export default function NodeModal({isDialogOpen, onOpenChange, form, editingNode
                                             <FormField
                                                 control={form.control}
                                                 name="max_logs"
-                                                render={({field}) => (
+                                                render={({ field }) => (
                                                     <FormItem className='flex-1'>
                                                         <FormLabel>{t('nodes.maxLogs')}</FormLabel>
                                                         <FormControl>
@@ -488,7 +488,7 @@ export default function NodeModal({isDialogOpen, onOpenChange, form, editingNode
                                                                 onChange={(e) => field.onChange(parseInt(e.target.value))}
                                                             />
                                                         </FormControl>
-                                                        <FormMessage/>
+                                                        <FormMessage />
                                                     </FormItem>
                                                 )}
                                             />
@@ -499,7 +499,7 @@ export default function NodeModal({isDialogOpen, onOpenChange, form, editingNode
                                             <FormField
                                                 control={form.control}
                                                 name="connection_type"
-                                                render={({field}) => (
+                                                render={({ field }) => (
                                                     <FormItem className='w-full'>
                                                         <FormLabel>{t('nodeModal.connectionType')}</FormLabel>
                                                         <Select
@@ -508,7 +508,7 @@ export default function NodeModal({isDialogOpen, onOpenChange, form, editingNode
                                                         >
                                                             <FormControl>
                                                                 <SelectTrigger>
-                                                                    <SelectValue placeholder="Rest"/>
+                                                                    <SelectValue placeholder="Rest" />
                                                                 </SelectTrigger>
                                                             </FormControl>
                                                             <SelectContent>
@@ -518,7 +518,7 @@ export default function NodeModal({isDialogOpen, onOpenChange, form, editingNode
                                                                     value={NodeConnectionType.rest}>Rest</SelectItem>
                                                             </SelectContent>
                                                         </Select>
-                                                        <FormMessage/>
+                                                        <FormMessage />
                                                     </FormItem>
                                                 )}
                                             />
@@ -526,7 +526,7 @@ export default function NodeModal({isDialogOpen, onOpenChange, form, editingNode
                                             <FormField
                                                 control={form.control}
                                                 name="api_key"
-                                                render={({field}) => {
+                                                render={({ field }) => {
                                                     const [uuidVersion, setUuidVersion] = useState<'v4' | 'v5' | 'v6' | 'v7'>('v4');
 
                                                     const generateUUID = () => {
@@ -568,7 +568,7 @@ export default function NodeModal({isDialogOpen, onOpenChange, form, editingNode
                                                                         >
                                                                             <SelectTrigger
                                                                                 className="w-[60px] h-full rounded-r-none border-r-0">
-                                                                                <SelectValue/>
+                                                                                <SelectValue />
                                                                             </SelectTrigger>
                                                                             <SelectContent>
                                                                                 <SelectItem value="v4">v4</SelectItem>
@@ -588,7 +588,7 @@ export default function NodeModal({isDialogOpen, onOpenChange, form, editingNode
                                                                     </div>
                                                                 </div>
                                                             </FormControl>
-                                                            <FormMessage/>
+                                                            <FormMessage />
                                                         </FormItem>
                                                     );
                                                 }}
@@ -597,7 +597,7 @@ export default function NodeModal({isDialogOpen, onOpenChange, form, editingNode
                                             <FormField
                                                 control={form.control}
                                                 name="keep_alive"
-                                                render={({field}) => {
+                                                render={({ field }) => {
                                                     const [displayValue, setDisplayValue] = useState<string>(field.value?.toString() || '');
                                                     const [unit, setUnit] = useState<'seconds' | 'minutes' | 'hours'>('seconds');
 
@@ -651,7 +651,7 @@ export default function NodeModal({isDialogOpen, onOpenChange, form, editingNode
                                                                         }}
                                                                     >
                                                                         <SelectTrigger className="flex-1">
-                                                                            <SelectValue/>
+                                                                            <SelectValue />
                                                                         </SelectTrigger>
                                                                         <SelectContent>
                                                                             <SelectItem
@@ -664,7 +664,7 @@ export default function NodeModal({isDialogOpen, onOpenChange, form, editingNode
                                                                     </Select>
                                                                 </div>
                                                             </div>
-                                                            <FormMessage/>
+                                                            <FormMessage />
                                                         </FormItem>
                                                     );
                                                 }}
@@ -676,7 +676,7 @@ export default function NodeModal({isDialogOpen, onOpenChange, form, editingNode
                                 <FormField
                                     control={form.control}
                                     name="server_ca"
-                                    render={({field}) => (
+                                    render={({ field }) => (
                                         <FormItem className="flex-1 w-full mb-6 md:mb-0 h-full">
                                             <FormLabel>{t('nodeModal.certificate')}</FormLabel>
                                             <FormControl>
@@ -687,7 +687,7 @@ export default function NodeModal({isDialogOpen, onOpenChange, form, editingNode
                                                     {...field}
                                                 />
                                             </FormControl>
-                                            <FormMessage/>
+                                            <FormMessage />
                                         </FormItem>
                                     )}
                                 />

--- a/dashboard/src/components/dialogs/QRCodeModal.tsx
+++ b/dashboard/src/components/dialogs/QRCodeModal.tsx
@@ -95,7 +95,7 @@ const QRCodeModal: FC<QRCodeModalProps> = memo(
                 <CarouselNext className="mr-6" />
               </Carousel>
               <span>
-                <span className="mx-2">{subscribeLinks[index-1]?.protocol}</span> {index} / {subscribeLinks?.length}
+                <span className="mx-2">{subscribeLinks[index - 1]?.protocol}</span> {index} / {subscribeLinks?.length}
               </span>
             </div>
           </div>

--- a/dashboard/src/components/dialogs/UserModal.tsx
+++ b/dashboard/src/components/dialogs/UserModal.tsx
@@ -1,22 +1,22 @@
-import {Dialog, DialogContent, DialogHeader, DialogTitle} from '@/components/ui/dialog';
-import {Form, FormControl, FormField, FormItem, FormLabel, FormMessage} from '@/components/ui/form';
-import {Input} from '@/components/ui/input';
-import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from '@/components/ui/select';
-import {Button} from '@/components/ui/button';
-import {useTranslation} from 'react-i18next';
-import {UseFormReturn} from 'react-hook-form';
-import {toast} from '@/hooks/use-toast';
-import {useState, useEffect} from 'react';
-import {UseFormValues, userCreateSchema} from '@/pages/_dashboard._index';
-import {RefreshCcw} from 'lucide-react';
-import {Calendar} from '@/components/ui/calendar';
-import {Popover, PopoverContent, PopoverTrigger} from '@/components/ui/popover';
-import {format} from 'date-fns';
-import {CalendarIcon} from 'lucide-react';
-import {cn} from '@/lib/utils';
-import {relativeExpiryDate} from '@/utils/dateFormatter';
-import {Textarea} from '@/components/ui/textarea';
-import {formatBytes} from '@/utils/formatByte';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Button } from '@/components/ui/button';
+import { useTranslation } from 'react-i18next';
+import { UseFormReturn } from 'react-hook-form';
+import { toast } from '@/hooks/use-toast';
+import { useState, useEffect } from 'react';
+import { UseFormValues, userCreateSchema } from '@/pages/_dashboard._index';
+import { RefreshCcw } from 'lucide-react';
+import { Calendar } from '@/components/ui/calendar';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { format } from 'date-fns';
+import { CalendarIcon } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { relativeExpiryDate } from '@/utils/dateFormatter';
+import { Textarea } from '@/components/ui/textarea';
+import { formatBytes } from '@/utils/formatByte';
 import {
     useGetUserTemplates,
     useGetAllGroups,
@@ -25,12 +25,14 @@ import {
     useModifyUser,
     useCreateUserFromTemplate
 } from '@/service/api';
-import {Layers, Users} from 'lucide-react';
-import {Checkbox} from '@/components/ui/checkbox';
-import {Search} from 'lucide-react';
+import { Layers, Users } from 'lucide-react';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Search } from 'lucide-react';
 import useDirDetection from '@/hooks/use-dir-detection';
-import {Switch} from '@/components/ui/switch';
-import {useQueryClient} from '@tanstack/react-query';
+import { Switch } from '@/components/ui/switch';
+import { useQueryClient } from '@tanstack/react-query';
+import { Trans } from 'react-i18next';
+import { useNavigate } from 'react-router';
 
 interface UserModalProps {
     isDialogOpen: boolean;
@@ -45,41 +47,42 @@ const isDate = (v: unknown): v is Date =>
     typeof v === 'object' && v !== null && v instanceof Date;
 
 export default function UserModal({
-                                      isDialogOpen,
-                                      onOpenChange,
-                                      form,
-                                      editingUser,
-                                      editingUserId,
-                                      onSuccessCallback
-                                  }: UserModalProps) {
-    const {t} = useTranslation();
+    isDialogOpen,
+    onOpenChange,
+    form,
+    editingUser,
+    editingUserId,
+    onSuccessCallback
+}: UserModalProps) {
+    const { t } = useTranslation();
     const dir = useDirDetection();
     const [loading, setLoading] = useState(false);
     const status = form.watch('status');
     const [activeTab, setActiveTab] = useState<'groups' | 'templates'>('groups');
     const tabs = [
-        {id: 'groups', label: 'groups', icon: Users},
-        {id: 'templates', label: 'templates.title', icon: Layers},
+        { id: 'groups', label: 'groups', icon: Users },
+        { id: 'templates', label: 'templates.title', icon: Layers },
     ];
     const [nextPlanEnabled, setNextPlanEnabled] = useState(!!form.watch('next_plan'));
     const [selectedTemplateId, setSelectedTemplateId] = useState<number | undefined>(undefined);
+    const navigate = useNavigate();
 
     // Query client for data refetching
     const queryClient = useQueryClient();
 
     // Get refetch function for users
-    const {refetch: refetchUsers} = useGetUsers({}, {
-        query: {enabled: false}
+    const { refetch: refetchUsers } = useGetUsers({}, {
+        query: { enabled: false }
     });
 
     // Function to refresh all user-related data
     const refreshUserData = () => {
         // Invalidate relevant queries to trigger fresh fetches
-        queryClient.invalidateQueries({queryKey: ['/api/users']});
-        queryClient.invalidateQueries({queryKey: ['getUsersUsage']});
-        queryClient.invalidateQueries({queryKey: ['getUserStats']});
-        queryClient.invalidateQueries({queryKey: ['getInboundStats']});
-        queryClient.invalidateQueries({queryKey: ['getUserOnlineStats']});
+        queryClient.invalidateQueries({ queryKey: ['/api/users'] });
+        queryClient.invalidateQueries({ queryKey: ['getUsersUsage'] });
+        queryClient.invalidateQueries({ queryKey: ['getUserStats'] });
+        queryClient.invalidateQueries({ queryKey: ['getInboundStats'] });
+        queryClient.invalidateQueries({ queryKey: ['getUserOnlineStats'] });
 
         // Force immediate refetch
         refetchUsers();
@@ -119,7 +122,7 @@ export default function UserModal({
         if (!editingUser) {
             form.setError('username', {
                 type: 'manual',
-                message: t('validation.required', {field: t('username')})
+                message: t('validation.required', { field: t('username') })
             });
         }
     }, [form, editingUser, t]);
@@ -134,7 +137,7 @@ export default function UserModal({
             if (!duration || duration < 1) {
                 form.setError('on_hold_expire_duration', {
                     type: 'manual',
-                    message: t('validation.required', {field: t('userDialog.onHoldExpireDuration')})
+                    message: t('validation.required', { field: t('userDialog.onHoldExpireDuration') })
                 });
             }
         } else {
@@ -213,7 +216,7 @@ export default function UserModal({
                     }
                 });
                 toast({
-                    title: t('success', {defaultValue: 'Success'}),
+                    title: t('success', { defaultValue: 'Success' }),
                     description: t('users.createSuccess', {
                         name: values.username,
                         defaultValue: 'User «{{name}}» has been created successfully'
@@ -267,7 +270,7 @@ export default function UserModal({
                     data: sendValues
                 });
                 toast({
-                    title: t('success', {defaultValue: 'Success'}),
+                    title: t('success', { defaultValue: 'Success' }),
                     description: t('users.editSuccess', {
                         name: values.username,
                         defaultValue: 'User «{{name}}» has been updated successfully'
@@ -278,7 +281,7 @@ export default function UserModal({
                     data: sendValues
                 });
                 toast({
-                    title: t('success', {defaultValue: 'Success'}),
+                    title: t('success', { defaultValue: 'Success' }),
                     description: t('users.createSuccess', {
                         name: values.username,
                         defaultValue: 'User «{{name}}» has been created successfully'
@@ -305,7 +308,7 @@ export default function UserModal({
                 if (error.errors.length > 0) {
                     const firstError = error.errors[0];
                     const fieldName = firstError.path[0] ?
-                        t(`userDialog.${firstError.path[0]}`, {defaultValue: firstError.path[0]}) :
+                        t(`userDialog.${firstError.path[0]}`, { defaultValue: firstError.path[0] }) :
                         'field';
 
                     // Set error on form if it's a recognized field
@@ -320,7 +323,7 @@ export default function UserModal({
                     }
 
                     toast({
-                        title: t('error', {defaultValue: 'Validation Error'}),
+                        title: t('error', { defaultValue: 'Validation Error' }),
                         description: t(`validation.${firstError.code}`, {
                             field: fieldName,
                             defaultValue: `${fieldName} is invalid`
@@ -347,15 +350,15 @@ export default function UserModal({
                 }
 
                 toast({
-                    title: t('error', {defaultValue: 'Error'}),
+                    title: t('error', { defaultValue: 'Error' }),
                     description: errorMessage,
                     variant: 'destructive',
                 });
             } else {
                 // Generic error handling
                 toast({
-                    title: t('error', {defaultValue: 'Error'}),
-                    description: error?.message || t('users.genericError', {defaultValue: 'An error occurred'}),
+                    title: t('error', { defaultValue: 'Error' }),
+                    description: error?.message || t('users.genericError', { defaultValue: 'An error occurred' }),
                     variant: 'destructive',
                 });
             }
@@ -370,8 +373,8 @@ export default function UserModal({
     }
 
     // Fetch data for tabs
-    const {data: templatesData, isLoading: templatesLoading} = useGetUserTemplates();
-    const {data: groupsData, isLoading: groupsLoading} = useGetAllGroups();
+    const { data: templatesData, isLoading: templatesLoading } = useGetUserTemplates();
+    const { data: groupsData, isLoading: groupsLoading } = useGetAllGroups();
 
 
     useEffect(() => {
@@ -394,12 +397,12 @@ export default function UserModal({
                 className={`lg:min-w-[900px]  ${editingUser ? "sm:h-auto h-full" : "h-auto"}`}>
                 <DialogHeader>
                     <DialogTitle
-                        className={`${dir === 'rtl' ? 'text-right' : ''}`}>{editingUser ? t('userDialog.editUser', {defaultValue: 'Edit User'}) : t('createUser', {defaultValue: 'Create User'})}</DialogTitle>
+                        className={`${dir === 'rtl' ? 'text-right' : ''}`}>{editingUser ? t('userDialog.editUser', { defaultValue: 'Edit User' }) : t('createUser', { defaultValue: 'Create User' })}</DialogTitle>
                 </DialogHeader>
                 <Form {...form}>
                     <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
                         <div
-                            className="max-h-[85vh] overflow-y-auto pr-4 -mr-4 sm:max-h-[75vh] px-2">
+                            className="max-h-[80vh] overflow-y-auto pr-4 -mr-4 sm:max-h-[75vh] px-2">
                             <div
                                 className='flex flex-col gap-6 lg:flex-row items-center lg:items-start justify-between w-full lg:pb-8'>
                                 <div className='space-y-6 flex-[2] w-full'>
@@ -410,13 +413,13 @@ export default function UserModal({
                                                 <FormField
                                                     control={form.control}
                                                     name="username"
-                                                    render={({field}) => (
+                                                    render={({ field }) => (
                                                         <FormItem className='flex-1'>
-                                                            <FormLabel>{t('username', {defaultValue: 'Username'})}</FormLabel>
+                                                            <FormLabel>{t('username', { defaultValue: 'Username' })}</FormLabel>
                                                             <FormControl>
                                                                 <div className="flex gap-2 items-center">
                                                                     <Input
-                                                                        placeholder={t('admins.enterUsername', {defaultValue: 'Enter username'})}
+                                                                        placeholder={t('admins.enterUsername', { defaultValue: 'Enter username' })}
                                                                         {...field}
                                                                         value={field.value ?? ''}
                                                                     />
@@ -427,38 +430,38 @@ export default function UserModal({
                                                                         onClick={() => field.onChange(generateUsername())}
                                                                         title="Generate username"
                                                                     >
-                                                                        <RefreshCcw className="w-3 h-3"/>
+                                                                        <RefreshCcw className="w-3 h-3" />
                                                                     </Button>
                                                                 </div>
                                                             </FormControl>
-                                                            <FormMessage/>
+                                                            <FormMessage />
                                                         </FormItem>
                                                     )}
                                                 />
                                                 <FormField
                                                     control={form.control}
                                                     name="status"
-                                                    render={({field}) => (
+                                                    render={({ field }) => (
                                                         <FormItem className='flex-1'>
-                                                            <FormLabel>{t('status', {defaultValue: 'Status'})}</FormLabel>
+                                                            <FormLabel>{t('status', { defaultValue: 'Status' })}</FormLabel>
                                                             <FormControl>
                                                                 <Select onValueChange={field.onChange}
-                                                                        value={field.value || ''}>
+                                                                    value={field.value || ''}>
                                                                     <SelectTrigger>
                                                                         <SelectValue
-                                                                            placeholder={t('users.selectStatus', {defaultValue: 'Select status'})}/>
+                                                                            placeholder={t('users.selectStatus', { defaultValue: 'Select status' })} />
                                                                     </SelectTrigger>
                                                                     <SelectContent>
                                                                         <SelectItem
-                                                                            value="active">{t('status.active', {defaultValue: 'Active'})}</SelectItem>
+                                                                            value="active">{t('status.active', { defaultValue: 'Active' })}</SelectItem>
                                                                         {editingUser && <SelectItem
-                                                                            value="disabled">{t('status.disabled', {defaultValue: 'Disabled'})}</SelectItem>}
+                                                                            value="disabled">{t('status.disabled', { defaultValue: 'Disabled' })}</SelectItem>}
                                                                         <SelectItem
-                                                                            value="on_hold">{t('status.on_hold', {defaultValue: 'On Hold'})}</SelectItem>
+                                                                            value="on_hold">{t('status.on_hold', { defaultValue: 'On Hold' })}</SelectItem>
                                                                     </SelectContent>
                                                                 </Select>
                                                             </FormControl>
-                                                            <FormMessage/>
+                                                            <FormMessage />
                                                         </FormItem>
                                                     )}
                                                 />
@@ -469,13 +472,13 @@ export default function UserModal({
                                             <FormField
                                                 control={form.control}
                                                 name="username"
-                                                render={({field}) => (
+                                                render={({ field }) => (
                                                     <FormItem className='flex-1'>
-                                                        <FormLabel>{t('username', {defaultValue: 'Username'})}</FormLabel>
+                                                        <FormLabel>{t('username', { defaultValue: 'Username' })}</FormLabel>
                                                         <FormControl>
                                                             <div className="flex gap-2 items-center">
                                                                 <Input
-                                                                    placeholder={t('admins.enterUsername', {defaultValue: 'Enter username'})}
+                                                                    placeholder={t('admins.enterUsername', { defaultValue: 'Enter username' })}
                                                                     {...field}
                                                                     value={field.value ?? ''}
                                                                 />
@@ -486,11 +489,11 @@ export default function UserModal({
                                                                     onClick={() => field.onChange(generateUsername())}
                                                                     title="Generate username"
                                                                 >
-                                                                    <RefreshCcw className="w-3 h-3"/>
+                                                                    <RefreshCcw className="w-3 h-3" />
                                                                 </Button>
                                                             </div>
                                                         </FormControl>
-                                                        <FormMessage/>
+                                                        <FormMessage />
                                                     </FormItem>
                                                 )}
                                             />
@@ -502,30 +505,34 @@ export default function UserModal({
                                             <FormField
                                                 control={form.control}
                                                 name="data_limit"
-                                                render={({field}) => (
+                                                render={({ field }) => (
                                                     <FormItem className='flex-1'>
-                                                        <FormLabel>{t('userDialog.dataLimit', {defaultValue: 'Data Limit (GB)'})}</FormLabel>
+                                                        <FormLabel>{t('userDialog.dataLimit', { defaultValue: 'Data Limit (GB)' })}</FormLabel>
                                                         <FormControl>
                                                             <div className="relative w-full">
                                                                 <Input
                                                                     type="number"
                                                                     step="any"
                                                                     min="0"
-                                                                    placeholder={t('userDialog.dataLimit', {defaultValue: 'e.g. 1'})}
-                                                                    {...field}
-                                                                    value={field.value === null || field.value === undefined ? '' : field.value}
+                                                                    placeholder={t('userDialog.dataLimit', { defaultValue: 'e.g. 1' })}
+                                                                    onChange={(e) => {
+                                                                        // Handle empty string properly
+                                                                        const value = e.target.value === '' ? undefined : Number(e.target.value);
+                                                                        field.onChange(value);
+                                                                    }}
+                                                                    value={field.value ?? ''}
                                                                     className="pr-12"
                                                                 />
                                                                 <span
                                                                     className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground pointer-events-none">GB</span>
                                                             </div>
                                                         </FormControl>
-                                                        {field.value && field.value < 1 && (
+                                                        {field.value !== null && field.value !== undefined && field.value > 0 && field.value < 1 && (
                                                             <p className="text-xs text-muted-foreground mt-1">
                                                                 {formatBytes(Math.round(field.value * 1024 * 1024 * 1024))}
                                                             </p>
                                                         )}
-                                                        <FormMessage/>
+                                                        <FormMessage />
                                                     </FormItem>
                                                 )}
                                             />
@@ -533,31 +540,31 @@ export default function UserModal({
                                                 <FormField
                                                     control={form.control}
                                                     name="data_limit_reset_strategy"
-                                                    render={({field}) => (
+                                                    render={({ field }) => (
                                                         <FormItem className="flex-1">
-                                                            <FormLabel>{t('userDialog.periodicUsageReset', {defaultValue: 'Periodic Usage Reset'})}</FormLabel>
+                                                            <FormLabel>{t('userDialog.periodicUsageReset', { defaultValue: 'Periodic Usage Reset' })}</FormLabel>
                                                             <Select onValueChange={field.onChange}
-                                                                    value={field.value || ''}>
+                                                                value={field.value || ''}>
                                                                 <FormControl>
                                                                     <SelectTrigger>
                                                                         <SelectValue
-                                                                            placeholder={t('userDialog.resetStrategyNo', {defaultValue: 'No'})}/>
+                                                                            placeholder={t('userDialog.resetStrategyNo', { defaultValue: 'No' })} />
                                                                     </SelectTrigger>
                                                                 </FormControl>
                                                                 <SelectContent>
                                                                     <SelectItem
-                                                                        value="no_reset">{t('userDialog.resetStrategyNo', {defaultValue: 'No'})}</SelectItem>
+                                                                        value="no_reset">{t('userDialog.resetStrategyNo', { defaultValue: 'No' })}</SelectItem>
                                                                     <SelectItem
-                                                                        value="day">{t('userDialog.resetStrategyDaily', {defaultValue: 'Daily'})}</SelectItem>
+                                                                        value="day">{t('userDialog.resetStrategyDaily', { defaultValue: 'Daily' })}</SelectItem>
                                                                     <SelectItem
-                                                                        value="week">{t('userDialog.resetStrategyWeekly', {defaultValue: 'Weekly'})}</SelectItem>
+                                                                        value="week">{t('userDialog.resetStrategyWeekly', { defaultValue: 'Weekly' })}</SelectItem>
                                                                     <SelectItem
-                                                                        value="month">{t('userDialog.resetStrategyMonthly', {defaultValue: 'Monthly'})}</SelectItem>
+                                                                        value="month">{t('userDialog.resetStrategyMonthly', { defaultValue: 'Monthly' })}</SelectItem>
                                                                     <SelectItem
-                                                                        value="year">{t('userDialog.resetStrategyAnnually', {defaultValue: 'Annually'})}</SelectItem>
+                                                                        value="year">{t('userDialog.resetStrategyAnnually', { defaultValue: 'Annually' })}</SelectItem>
                                                                 </SelectContent>
                                                             </Select>
-                                                            <FormMessage/>
+                                                            <FormMessage />
                                                         </FormItem>
                                                     )}
                                                 />)}
@@ -566,19 +573,19 @@ export default function UserModal({
                                                     <FormField
                                                         control={form.control}
                                                         name="on_hold_expire_duration"
-                                                        render={({field}) => (
+                                                        render={({ field }) => (
                                                             <FormItem className="flex-1">
-                                                                <FormLabel>{t('userDialog.onHoldExpireDuration', {defaultValue: 'On Hold Expire Duration (days)'})}</FormLabel>
+                                                                <FormLabel>{t('userDialog.onHoldExpireDuration', { defaultValue: 'On Hold Expire Duration (days)' })}</FormLabel>
                                                                 <FormControl>
                                                                     <Input
                                                                         type="number"
                                                                         min="1"
-                                                                        placeholder={t('userDialog.onHoldExpireDurationPlaceholder', {defaultValue: 'e.g. 7'})}
+                                                                        placeholder={t('userDialog.onHoldExpireDurationPlaceholder', { defaultValue: 'e.g. 7' })}
                                                                         {...field}
                                                                         value={field.value === null || field.value === undefined ? '' : field.value}
                                                                     />
                                                                 </FormControl>
-                                                                <FormMessage/>
+                                                                <FormMessage />
                                                             </FormItem>
                                                         )}
                                                     />
@@ -587,7 +594,7 @@ export default function UserModal({
                                                     <FormField
                                                         control={form.control}
                                                         name="expire"
-                                                        render={({field}) => {
+                                                        render={({ field }) => {
                                                             let expireUnix: number | null = null;
                                                             let displayDate: Date | null = null;
 
@@ -634,7 +641,7 @@ export default function UserModal({
 
                                                             return (
                                                                 <FormItem className="flex flex-col flex-1">
-                                                                    <FormLabel>{t('userDialog.expiryDate', {defaultValue: 'Expire date'})}</FormLabel>
+                                                                    <FormLabel>{t('userDialog.expiryDate', { defaultValue: 'Expire date' })}</FormLabel>
                                                                     <Popover>
                                                                         <PopoverTrigger asChild>
                                                                             <FormControl>
@@ -651,15 +658,15 @@ export default function UserModal({
                                                                                         : field.value && !isNaN(Number(field.value))
                                                                                             ? String(field.value)
                                                                                             :
-                                                                                            <span>{t('users.expirePlaceholder', {defaultValue: 'Pick a date'})}</span>
+                                                                                            <span>{t('users.expirePlaceholder', { defaultValue: 'Pick a date' })}</span>
                                                                                     }
                                                                                     <CalendarIcon
-                                                                                        className="ml-auto h-4 w-4 opacity-50"/>
+                                                                                        className="ml-auto h-4 w-4 opacity-50" />
                                                                                 </Button>
                                                                             </FormControl>
                                                                         </PopoverTrigger>
                                                                         <PopoverContent className="w-auto p-0"
-                                                                                        align="start">
+                                                                            align="start">
                                                                             <Calendar
                                                                                 mode="single"
                                                                                 selected={displayDate || undefined}
@@ -679,9 +686,9 @@ export default function UserModal({
                                                                     </Popover>
                                                                     {expireInfo?.time && (
                                                                         <p dir="ltr"
-                                                                           className="text-xs text-muted-foreground mt-1">{expireInfo.time} later</p>
+                                                                            className="text-xs text-muted-foreground mt-1">{expireInfo.time} later</p>
                                                                     )}
-                                                                    <FormMessage/>
+                                                                    <FormMessage />
                                                                 </FormItem>
                                                             );
                                                         }}
@@ -693,17 +700,17 @@ export default function UserModal({
                                     <FormField
                                         control={form.control}
                                         name="note"
-                                        render={({field}) => (
+                                        render={({ field }) => (
                                             <FormItem>
-                                                <FormLabel>{t('userDialog.note', {defaultValue: 'Note'})}</FormLabel>
+                                                <FormLabel>{t('userDialog.note', { defaultValue: 'Note' })}</FormLabel>
                                                 <FormControl>
                                                     <Textarea
-                                                        placeholder={t('userDialog.note', {defaultValue: 'Optional note'}) + "..."}
+                                                        placeholder={t('userDialog.note', { defaultValue: 'Optional note' }) + "..."}
                                                         {...field}
                                                         rows={3}
                                                     />
                                                 </FormControl>
-                                                <FormMessage/>
+                                                <FormMessage />
                                             </FormItem>
                                         )}
                                     />
@@ -712,17 +719,17 @@ export default function UserModal({
                                         <>
                                             <div className="flex items-center justify-between mb-2">
                                                 <div
-                                                    className="font-semibold">{t('userDialog.nextPlanTitle', {defaultValue: 'Next Plan'})}</div>
-                                                <Switch checked={nextPlanEnabled} onCheckedChange={setNextPlanEnabled}/>
+                                                    className="font-semibold">{t('userDialog.nextPlanTitle', { defaultValue: 'Next Plan' })}</div>
+                                                <Switch checked={nextPlanEnabled} onCheckedChange={setNextPlanEnabled} />
                                             </div>
                                             {nextPlanEnabled && (
                                                 <div className="flex flex-col gap-4">
                                                     <FormField
                                                         control={form.control}
                                                         name="next_plan.user_template_id"
-                                                        render={({field}) => (
+                                                        render={({ field }) => (
                                                             <FormItem>
-                                                                <FormLabel>{t('userDialog.nextPlanTemplate', {defaultValue: 'Template'})}</FormLabel>
+                                                                <FormLabel>{t('userDialog.nextPlanTemplate', { defaultValue: 'Template' })}</FormLabel>
                                                                 <FormControl>
                                                                     <Select
                                                                         value={field.value ? String(field.value) : "none"}
@@ -736,18 +743,18 @@ export default function UserModal({
                                                                     >
                                                                         <SelectTrigger>
                                                                             <SelectValue
-                                                                                placeholder={t('userDialog.selectTemplatePlaceholder', {defaultValue: 'Choose a template'})}/>
+                                                                                placeholder={t('userDialog.selectTemplatePlaceholder', { defaultValue: 'Choose a template' })} />
                                                                         </SelectTrigger>
                                                                         <SelectContent>
                                                                             <SelectItem value="none">---</SelectItem>
                                                                             {(templatesData || []).map((tpl: any) => (
                                                                                 <SelectItem key={tpl.id}
-                                                                                            value={String(tpl.id)}>{tpl.name}</SelectItem>
+                                                                                    value={String(tpl.id)}>{tpl.name}</SelectItem>
                                                                             ))}
                                                                         </SelectContent>
                                                                     </Select>
                                                                 </FormControl>
-                                                                <FormMessage/>
+                                                                <FormMessage />
                                                             </FormItem>
                                                         )}
                                                     />
@@ -757,33 +764,33 @@ export default function UserModal({
                                                             <FormField
                                                                 control={form.control}
                                                                 name="next_plan.expire"
-                                                                render={({field}) => (
+                                                                render={({ field }) => (
                                                                     <FormItem>
-                                                                        <FormLabel>{t('userDialog.nextPlanExpire', {defaultValue: 'Expire'})}</FormLabel>
+                                                                        <FormLabel>{t('userDialog.nextPlanExpire', { defaultValue: 'Expire' })}</FormLabel>
                                                                         <FormControl>
                                                                             <Input type="number" min="0" {...field}
-                                                                                   value={field.value ?? ''}/>
+                                                                                value={field.value ?? ''} />
                                                                         </FormControl>
                                                                         <span
-                                                                            className="text-xs text-muted-foreground">{t('userDialog.days', {defaultValue: 'Days'})}</span>
-                                                                        <FormMessage/>
+                                                                            className="text-xs text-muted-foreground">{t('userDialog.days', { defaultValue: 'Days' })}</span>
+                                                                        <FormMessage />
                                                                     </FormItem>
                                                                 )}
                                                             />
                                                             <FormField
                                                                 control={form.control}
                                                                 name="next_plan.data_limit"
-                                                                render={({field}) => (
+                                                                render={({ field }) => (
                                                                     <FormItem>
-                                                                        <FormLabel>{t('userDialog.nextPlanDataLimit', {defaultValue: 'Data Limit'})}</FormLabel>
+                                                                        <FormLabel>{t('userDialog.nextPlanDataLimit', { defaultValue: 'Data Limit' })}</FormLabel>
                                                                         <FormControl>
                                                                             <Input type="number" min="0"
-                                                                                   step="any" {...field}
-                                                                                   value={field.value ?? ''}/>
+                                                                                step="any" {...field}
+                                                                                value={field.value ?? ''} />
                                                                         </FormControl>
                                                                         <span
                                                                             className="text-xs text-muted-foreground">GB</span>
-                                                                        <FormMessage/>
+                                                                        <FormMessage />
                                                                     </FormItem>
                                                                 )}
                                                             />
@@ -793,24 +800,24 @@ export default function UserModal({
                                                         <FormField
                                                             control={form.control}
                                                             name="next_plan.add_remaining_traffic"
-                                                            render={({field}) => (
+                                                            render={({ field }) => (
                                                                 <FormItem className="flex flex-row items-center gap-2">
                                                                     <Switch checked={!!field.value}
-                                                                            onCheckedChange={field.onChange}/>
-                                                                    <FormLabel>{t('userDialog.nextPlanAddRemainingTraffic', {defaultValue: 'Add Remaining Traffic'})}</FormLabel>
-                                                                    <FormMessage/>
+                                                                        onCheckedChange={field.onChange} />
+                                                                    <FormLabel>{t('userDialog.nextPlanAddRemainingTraffic', { defaultValue: 'Add Remaining Traffic' })}</FormLabel>
+                                                                    <FormMessage />
                                                                 </FormItem>
                                                             )}
                                                         />
                                                         <FormField
                                                             control={form.control}
                                                             name="next_plan.fire_on_either"
-                                                            render={({field}) => (
+                                                            render={({ field }) => (
                                                                 <FormItem className="flex flex-row items-center gap-2">
                                                                     <Switch checked={!!field.value}
-                                                                            onCheckedChange={field.onChange}/>
-                                                                    <FormLabel>{t('userDialog.nextPlanFireOnEither', {defaultValue: 'Fire On Either'})}</FormLabel>
-                                                                    <FormMessage/>
+                                                                        onCheckedChange={field.onChange} />
+                                                                    <FormLabel>{t('userDialog.nextPlanFireOnEither', { defaultValue: 'Fire On Either' })}</FormLabel>
+                                                                    <FormMessage />
                                                                 </FormItem>
                                                             )}
                                                         />
@@ -830,11 +837,11 @@ export default function UserModal({
                                                     className={`relative px-3 py-2 text-sm font-medium transition-colors ${activeTab === tab.id
                                                         ? 'text-foreground border-b-2 border-primary'
                                                         : 'text-muted-foreground hover:text-foreground'
-                                                    }`}
+                                                        }`}
                                                     type="button"
                                                 >
                                                     <div className="flex items-center gap-1.5">
-                                                        <tab.icon className="h-4 w-4"/>
+                                                        <tab.icon className="h-4 w-4" />
                                                         <span>{t(tab.label)}</span>
                                                     </div>
                                                 </button>
@@ -843,9 +850,9 @@ export default function UserModal({
                                         <div className="py-2">
                                             {activeTab === 'templates' && (
                                                 templatesLoading ?
-                                                    <div>{t('Loading...', {defaultValue: 'Loading...'})}</div> :
+                                                    <div>{t('Loading...', { defaultValue: 'Loading...' })}</div> :
                                                     <div className="space-y-4 pt-4">
-                                                        <FormLabel>{t('userDialog.selectTemplate', {defaultValue: 'Select Template'})}</FormLabel>
+                                                        <FormLabel>{t('userDialog.selectTemplate', { defaultValue: 'Select Template' })}</FormLabel>
                                                         <Select
                                                             value={selectedTemplateId ? String(selectedTemplateId) : 'none'}
                                                             onValueChange={val => {
@@ -860,13 +867,13 @@ export default function UserModal({
                                                         >
                                                             <SelectTrigger>
                                                                 <SelectValue
-                                                                    placeholder={t('userDialog.selectTemplatePlaceholder', {defaultValue: 'Choose a template'})}/>
+                                                                    placeholder={t('userDialog.selectTemplatePlaceholder', { defaultValue: 'Choose a template' })} />
                                                             </SelectTrigger>
                                                             <SelectContent>
                                                                 <SelectItem value="none">---</SelectItem>
                                                                 {(templatesData || []).map((template: any) => (
                                                                     <SelectItem key={template.id}
-                                                                                value={String(template.id)}>{template.name}</SelectItem>
+                                                                        value={String(template.id)}>{template.name}</SelectItem>
                                                                 ))}
                                                             </SelectContent>
                                                         </Select>
@@ -882,11 +889,11 @@ export default function UserModal({
                                             )}
                                             {activeTab === 'groups' && (
                                                 groupsLoading ?
-                                                    <div>{t('Loading...', {defaultValue: 'Loading...'})}</div> :
+                                                    <div>{t('Loading...', { defaultValue: 'Loading...' })}</div> :
                                                     <FormField
                                                         control={form.control}
                                                         name="group_ids"
-                                                        render={({field}) => {
+                                                        render={({ field }) => {
                                                             const [searchQuery, setSearchQuery] = useState('');
                                                             const selectedGroups = field.value || [];
                                                             const filteredGroups = (groupsData?.groups || []).filter((group: any) =>
@@ -919,9 +926,9 @@ export default function UserModal({
                                                                     <div className="space-y-4 pt-4">
                                                                         <div className="relative">
                                                                             <Search
-                                                                                className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground"/>
+                                                                                className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground" />
                                                                             <Input
-                                                                                placeholder={t('search', {defaultValue: 'Search'}) + " " + t("groups", {defaultValue: "groups"})}
+                                                                                placeholder={t('search', { defaultValue: 'Search' }) + " " + t("groups", { defaultValue: "groups" })}
                                                                                 value={searchQuery}
                                                                                 onChange={(e) => setSearchQuery(e.target.value)}
                                                                                 className="pl-8"
@@ -934,15 +941,33 @@ export default function UserModal({
                                                                                 onCheckedChange={handleSelectAll}
                                                                             />
                                                                             <span className="text-sm font-medium">
-                                      {t('selectAll', {defaultValue: 'Select All'})}
-                                    </span>
+                                                                                {t('selectAll', { defaultValue: 'Select All' })}
+                                                                            </span>
                                                                         </div>
                                                                         <div
                                                                             className="max-h-[200px] overflow-y-auto space-y-2 p-2 border rounded-md">
                                                                             {filteredGroups.length === 0 ? (
-                                                                                <div
-                                                                                    className="text-sm text-muted-foreground text-center py-4">
-                                                                                    {t('users.noGroupsFound', {defaultValue: 'No groups found'})}
+                                                                                <div className="flex flex-col gap-4 w-full border-yellow-500 border p-4 rounded-md">
+                                                                                    <span className="text-sm font-bold text-yellow-500">
+                                                                                        {t('warning')}
+                                                                                    </span>
+                                                                                    <span className="text-sm font-medium text-foreground">
+                                                                                        <Trans i18nKey={'templates.groupsExistingWarning'}
+                                                                                            components={{
+                                                                                                a: (
+                                                                                                    <a
+                                                                                                        href="/groups"
+                                                                                                        className="font-bold text-primary hover:underline"
+                                                                                                        onClick={(e) => {
+                                                                                                            e.preventDefault();
+                                                                                                            navigate('/groups');
+                                                                                                        }}
+                                                                                                    />
+                                                                                                )
+                                                                                            }}
+                                                                                        >
+                                                                                        </Trans>
+                                                                                    </span>
                                                                                 </div>
                                                                             ) : (
                                                                                 filteredGroups.map((group: any) => (
@@ -970,7 +995,7 @@ export default function UserModal({
                                                                             </div>
                                                                         )}
                                                                     </div>
-                                                                    <FormMessage/>
+                                                                    <FormMessage />
                                                                 </FormItem>
                                                             );
                                                         }}
@@ -984,10 +1009,10 @@ export default function UserModal({
                         {/* Cancel/Create buttons - always visible */}
                         <div className="flex justify-end gap-2 mt-4">
                             <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
-                                {t('cancel', {defaultValue: 'Cancel'})}
+                                {t('cancel', { defaultValue: 'Cancel' })}
                             </Button>
-                            <Button type="submit" disabled={loading}>
-                                {editingUser ? t('save', {defaultValue: 'Save'}) : t('create', {defaultValue: 'Create'})}
+                            <Button type="submit" disabled={loading || (groupsData?.groups?.length === 0 && !selectedTemplateId)}>
+                                {editingUser ? t('save', { defaultValue: 'Save' }) : t('create', { defaultValue: 'Create' })}
                             </Button>
                         </div>
                     </form>

--- a/dashboard/src/components/dialogs/UserTemplateModal.tsx
+++ b/dashboard/src/components/dialogs/UserTemplateModal.tsx
@@ -1,4 +1,4 @@
-import {z} from "zod";
+import { z } from "zod";
 import {
     ShadowsocksMethods,
     useCreateUserTemplate,
@@ -7,25 +7,25 @@ import {
     XTLSFlows,
     UserDataLimitResetStrategy, useGetAllGroups
 } from '@/service/api'
-import {UseFormReturn} from "react-hook-form";
-import {Trans, useTranslation} from "react-i18next";
+import { UseFormReturn } from "react-hook-form";
+import { Trans, useTranslation } from "react-i18next";
 import useDirDetection from "@/hooks/use-dir-detection.tsx";
-import {toast} from "@/hooks/use-toast.ts";
-import {queryClient} from "@/utils/query-client.ts";
-import {Dialog, DialogContent, DialogHeader, DialogTitle} from "@/components/ui/dialog.tsx";
-import {cn} from "@/lib/utils.ts";
-import {Form, FormControl, FormField, FormItem, FormLabel, FormMessage} from "@/components/ui/form.tsx";
-import {Input} from "@/components/ui/input.tsx";
-import {Button} from "@/components/ui/button.tsx";
-import {Select, SelectContent, SelectItem, SelectTrigger, SelectValue} from "@/components/ui/select.tsx";
-import {Search} from "lucide-react";
-import {useEffect, useState, useCallback} from "react";
-import {Switch} from "@/components/ui/switch.tsx";
-import {useNavigate} from "react-router";
-import {Checkbox} from "@/components/ui/checkbox.tsx";
+import { toast } from "@/hooks/use-toast.ts";
+import { queryClient } from "@/utils/query-client.ts";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog.tsx";
+import { cn } from "@/lib/utils.ts";
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form.tsx";
+import { Input } from "@/components/ui/input.tsx";
+import { Button } from "@/components/ui/button.tsx";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select.tsx";
+import { Search } from "lucide-react";
+import { useEffect, useState, useCallback } from "react";
+import { Switch } from "@/components/ui/switch.tsx";
+import { useNavigate } from "react-router";
+import { Checkbox } from "@/components/ui/checkbox.tsx";
 
 export const userTemplateFormSchema = z.object({
-    name: z.string().min(1, {message: 'validation.required'}),
+    name: z.string().min(1, { message: 'validation.required' }),
     status: z.enum([UserStatusCreate.active, UserStatusCreate.on_hold]).default(UserStatusCreate.active),
     username_prefix: z.string().optional(),
     username_suffix: z.string().optional(),
@@ -34,7 +34,7 @@ export const userTemplateFormSchema = z.object({
     on_hold_timeout: z.number().optional(),
     method: z.enum([ShadowsocksMethods["aes-128-gcm"], ShadowsocksMethods["aes-256-gcm"], ShadowsocksMethods["chacha20-ietf-poly1305"], ShadowsocksMethods["xchacha20-poly1305"]]).optional(),
     flow: z.enum([XTLSFlows[""], XTLSFlows["xtls-rprx-vision"]]).optional(),
-    groups: z.array(z.number()).min(1, {message: 'validation.required'}),
+    groups: z.array(z.number()).min(1, { message: 'validation.required' }),
     resetUsages: z.boolean().optional().default(false),
     data_limit_reset_strategy: z.enum([UserDataLimitResetStrategy["month"], UserDataLimitResetStrategy["day"], UserDataLimitResetStrategy["week"], UserDataLimitResetStrategy["no_reset"], UserDataLimitResetStrategy["week"], UserDataLimitResetStrategy["year"]]).optional(),
 })
@@ -50,21 +50,21 @@ interface UserTemplatesModalprops {
 }
 
 export default function UserTemplateModal({
-                                              isDialogOpen,
-                                              onOpenChange,
-                                              form,
-                                              editingUserTemplate,
-                                              editingUserTemplateId
-                                          }: UserTemplatesModalprops) {
-    const {t} = useTranslation()
+    isDialogOpen,
+    onOpenChange,
+    form,
+    editingUserTemplate,
+    editingUserTemplateId
+}: UserTemplatesModalprops) {
+    const { t } = useTranslation()
     const dir = useDirDetection()
     const addUserTemplateMutation = useCreateUserTemplate()
     const modifyUserTemplateMutation = useModifyUserTemplate()
-    const {data} = useGetAllGroups({})
+    const { data } = useGetAllGroups({})
     const [checkGroups, setCheckGroups] = useState(false)
     const [timeType, setTimeType] = useState<"seconds" | "hours" | "days">("seconds")
     const navigate = useNavigate()
-    const {data: groupsData, isLoading: groupsLoading} = useGetAllGroups();
+    const { data: groupsData, isLoading: groupsLoading } = useGetAllGroups();
 
     const checkGroupsExist = useCallback(() => {
         if (!data?.groups || data.groups.length === 0) {
@@ -108,7 +108,7 @@ export default function UserTemplateModal({
                     data: submitData
                 })
                 toast({
-                    title: t('success', {defaultValue: 'Success'}),
+                    title: t('success', { defaultValue: 'Success' }),
                     description: t('templates.editSuccess', {
                         name: values.name,
                         defaultValue: 'User Templates «{name}» has been updated successfully'
@@ -119,7 +119,7 @@ export default function UserTemplateModal({
                     data: submitData
                 })
                 toast({
-                    title: t('success', {defaultValue: 'Success'}),
+                    title: t('success', { defaultValue: 'Success' }),
                     description: t('templates.createSuccess', {
                         name: values.name,
                         defaultValue: 'User Templates «{name}» has been created successfully'
@@ -128,13 +128,13 @@ export default function UserTemplateModal({
             }
 
             // Invalidate nodes queries after successful operation
-            queryClient.invalidateQueries({queryKey: ['/api/user_templates']});
+            queryClient.invalidateQueries({ queryKey: ['/api/user_templates'] });
             onOpenChange(false)
             form.reset()
         } catch (error: any) {
             console.error('User Templates operation failed:', error)
             toast({
-                title: t('error', {defaultValue: 'Error'}),
+                title: t('error', { defaultValue: 'Error' }),
                 description: t(editingUserTemplate ? 'templates.editFailed' : 'templates.createFailed', {
                     name: values.name,
                     error: error?.message || '',
@@ -163,14 +163,14 @@ export default function UserTemplateModal({
                                     <FormField
                                         control={form.control}
                                         name="name"
-                                        render={({field}) => (
+                                        render={({ field }) => (
                                             <FormItem>
                                                 <FormLabel>{t('templates.name')}</FormLabel>
                                                 <FormControl>
                                                     <Input placeholder={t('templates.name')} {...field}
-                                                           className="min-w-40 sm:w-72"/>
+                                                        className="min-w-40 sm:w-72" />
                                                 </FormControl>
-                                                <FormMessage/>
+                                                <FormMessage />
                                             </FormItem>
                                         )}
                                     />
@@ -178,7 +178,7 @@ export default function UserTemplateModal({
                                     <FormField
                                         control={form.control}
                                         name="status"
-                                        render={({field}) => (
+                                        render={({ field }) => (
                                             <FormItem className='w-full'>
                                                 <FormLabel>{t('templates.status')}</FormLabel>
                                                 <Select
@@ -187,14 +187,14 @@ export default function UserTemplateModal({
                                                 >
                                                     <FormControl>
                                                         <SelectTrigger>
-                                                            <SelectValue placeholder="Active"/>
+                                                            <SelectValue placeholder="Active" />
                                                         </SelectTrigger>
                                                     </FormControl>
                                                     <SelectContent>
                                                         <SelectItem
-                                                            value={UserStatusCreate.active}>Active</SelectItem>
+                                                            value={UserStatusCreate.active}>{t('status.active')}</SelectItem>
                                                         <SelectItem
-                                                            value={UserStatusCreate.on_hold}>OnHold</SelectItem>
+                                                            value={UserStatusCreate.on_hold}>{t('status.on_hold')}</SelectItem>
                                                     </SelectContent>
                                                 </Select>
                                             </FormItem>
@@ -205,7 +205,7 @@ export default function UserTemplateModal({
                                 <FormField
                                     control={form.control}
                                     name="username_prefix"
-                                    render={({field}) => (
+                                    render={({ field }) => (
                                         <FormItem>
                                             <FormLabel>{t('templates.prefix')}</FormLabel>
                                             <FormControl>
@@ -216,7 +216,7 @@ export default function UserTemplateModal({
                                                     onChange={(e) => field.onChange(e.target.value)}
                                                 />
                                             </FormControl>
-                                            <FormMessage/>
+                                            <FormMessage />
                                         </FormItem>
                                     )}
                                 />
@@ -224,7 +224,7 @@ export default function UserTemplateModal({
                                 <FormField
                                     control={form.control}
                                     name="username_suffix"
-                                    render={({field}) => (
+                                    render={({ field }) => (
                                         <FormItem>
                                             <FormLabel>{t('templates.suffix')}</FormLabel>
                                             <FormControl>
@@ -235,7 +235,7 @@ export default function UserTemplateModal({
                                                     onChange={(e) => field.onChange(e.target.value)}
                                                 />
                                             </FormControl>
-                                            <FormMessage/>
+                                            <FormMessage />
                                         </FormItem>
                                     )}
                                 />
@@ -243,7 +243,7 @@ export default function UserTemplateModal({
                                 <FormField
                                     control={form.control}
                                     name="data_limit"
-                                    render={({field}) => (
+                                    render={({ field }) => (
                                         <FormItem className='flex-1'>
                                             <FormLabel>{t('templates.dataLimit')}</FormLabel>
                                             <FormControl>
@@ -264,14 +264,14 @@ export default function UserTemplateModal({
                                                         className="absolute right-3 top-1/2 -translate-y-1/2 text-sm text-muted-foreground font-medium pointer-events-none">GB</span>
                                                 </div>
                                             </FormControl>
-                                            <FormMessage/>
+                                            <FormMessage />
                                         </FormItem>
                                     )}
                                 />
                                 <FormField
                                     control={form.control}
                                     name="resetUsages"
-                                    render={({field}) => (
+                                    render={({ field }) => (
                                         <FormItem className='flex-1'>
                                             <div className="flex-row justify-between items-center flex">
                                                 <FormLabel>{t('templates.resetUsage')}</FormLabel>
@@ -281,7 +281,7 @@ export default function UserTemplateModal({
                                                         onCheckedChange={field.onChange}
                                                     />
                                                 </FormControl>
-                                                <FormMessage/>
+                                                <FormMessage />
                                             </div>
                                         </FormItem>
                                     )}
@@ -289,7 +289,7 @@ export default function UserTemplateModal({
                                 <FormField
                                     control={form.control}
                                     name="data_limit_reset_strategy"
-                                    render={({field}) => {
+                                    render={({ field }) => {
                                         // Only show if resetUsages is enabled
                                         const resetUsages = form.watch("resetUsages");
                                         if (!resetUsages) {
@@ -304,7 +304,7 @@ export default function UserTemplateModal({
                                                 >
                                                     <FormControl>
                                                         <SelectTrigger>
-                                                            <SelectValue placeholder=""/>
+                                                            <SelectValue placeholder="" />
                                                         </SelectTrigger>
                                                     </FormControl>
                                                     <SelectContent>
@@ -320,7 +320,7 @@ export default function UserTemplateModal({
                                                             value={UserDataLimitResetStrategy["year"]}>Year</SelectItem>
                                                     </SelectContent>
                                                 </Select>
-                                                <FormMessage/>
+                                                <FormMessage />
                                             </FormItem>
                                         );
                                     }}
@@ -328,7 +328,7 @@ export default function UserTemplateModal({
                                 <FormField
                                     control={form.control}
                                     name="expire_duration"
-                                    render={({field}) => (
+                                    render={({ field }) => (
                                         <FormItem className='flex-1'>
                                             <FormLabel>{t('templates.expire')}</FormLabel>
                                             <FormControl>
@@ -348,14 +348,14 @@ export default function UserTemplateModal({
                                                         className="absolute right-3 top-1/2 -translate-y-1/2 text-sm text-muted-foreground font-medium pointer-events-none">Days</span>
                                                 </div>
                                             </FormControl>
-                                            <FormMessage/>
+                                            <FormMessage />
                                         </FormItem>
                                     )}
                                 />
                                 <FormField
                                     control={form.control}
                                     name="on_hold_timeout"
-                                    render={({field}) => {
+                                    render={({ field }) => {
                                         const changeValue = (value: number | undefined) => {
                                             if (!value)
                                                 return value
@@ -393,10 +393,10 @@ export default function UserTemplateModal({
                                                         </div>
                                                         <div className="flex-[2]">
                                                             <Select value={timeType}
-                                                                    onValueChange={(v) => setTimeType(v as any)}>
+                                                                onValueChange={(v) => setTimeType(v as any)}>
                                                                 <SelectTrigger
                                                                     className="w-full rounded-none border-0 focus:ring-0 focus:ring-offset-0">
-                                                                    <SelectValue placeholder="Second"/>
+                                                                    <SelectValue placeholder="Second" />
                                                                 </SelectTrigger>
                                                                 <SelectContent>
                                                                     <SelectItem value="days">Days</SelectItem>
@@ -407,7 +407,7 @@ export default function UserTemplateModal({
                                                         </div>
                                                     </div>
                                                 </FormControl>
-                                                <FormMessage/>
+                                                <FormMessage />
                                             </FormItem>
                                         )
                                     }}
@@ -418,7 +418,7 @@ export default function UserTemplateModal({
                                 <FormField
                                     control={form.control}
                                     name="method"
-                                    render={({field}) => (
+                                    render={({ field }) => (
                                         <FormItem>
                                             <FormLabel>{t('templates.method')}</FormLabel>
                                             <Select
@@ -427,7 +427,7 @@ export default function UserTemplateModal({
                                             >
                                                 <FormControl>
                                                     <SelectTrigger>
-                                                        <SelectValue placeholder="Select Method"/>
+                                                        <SelectValue placeholder="Select Method" />
                                                     </SelectTrigger>
                                                 </FormControl>
                                                 <SelectContent>
@@ -442,7 +442,7 @@ export default function UserTemplateModal({
                                                         value={ShadowsocksMethods["xchacha20-poly1305"]}>xchacha20-poly1305</SelectItem>
                                                 </SelectContent>
                                             </Select>
-                                            <FormMessage/>
+                                            <FormMessage />
                                         </FormItem>
                                     )}
                                 />
@@ -450,7 +450,7 @@ export default function UserTemplateModal({
                                 <FormField
                                     control={form.control}
                                     name="flow"
-                                    render={({field}) => (
+                                    render={({ field }) => (
                                         <FormItem>
                                             <FormLabel>{t('templates.flow')}</FormLabel>
                                             <Select
@@ -459,7 +459,7 @@ export default function UserTemplateModal({
                                             >
                                                 <FormControl>
                                                     <SelectTrigger>
-                                                        <SelectValue placeholder=""/>
+                                                        <SelectValue placeholder="" />
                                                     </SelectTrigger>
                                                 </FormControl>
                                                 <SelectContent>
@@ -468,15 +468,15 @@ export default function UserTemplateModal({
                                                         value={XTLSFlows["xtls-rprx-vision"]}>xtls-rprx-vision</SelectItem>
                                                 </SelectContent>
                                             </Select>
-                                            <FormMessage/>
+                                            <FormMessage />
                                         </FormItem>
-                                    )}/>
+                                    )} />
                                 {
-                                    groupsLoading ? <div>{t('Loading...', {defaultValue: 'Loading...'})}</div> :
+                                    groupsLoading ? <div>{t('Loading...', { defaultValue: 'Loading...' })}</div> :
                                         <FormField
                                             control={form.control}
                                             name="groups"
-                                            render={({field}) => {
+                                            render={({ field }) => {
                                                 const [searchQuery, setSearchQuery] = useState('');
                                                 const selectedGroups = field.value || [];
                                                 const filteredGroups = (groupsData?.groups || []).filter((group: any) =>
@@ -508,9 +508,9 @@ export default function UserTemplateModal({
                                                         <div className="space-y-4 pt-4">
                                                             <div className="relative">
                                                                 <Search
-                                                                    className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground"/>
+                                                                    className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground" />
                                                                 <Input
-                                                                    placeholder={t('search', {defaultValue: 'Search'}) + " " + t("groups", {defaultValue: "groups"})}
+                                                                    placeholder={t('search', { defaultValue: 'Search' }) + " " + t("groups", { defaultValue: "groups" })}
                                                                     value={searchQuery}
                                                                     onChange={(e) => setSearchQuery(e.target.value)}
                                                                     className="pl-8"
@@ -523,36 +523,36 @@ export default function UserTemplateModal({
                                                                     onCheckedChange={handleSelectAll}
                                                                 />
                                                                 <span className="text-sm font-medium">
-                                      {t('selectAll', {defaultValue: 'Select All'})}
-                                    </span>
+                                                                    {t('selectAll', { defaultValue: 'Select All' })}
+                                                                </span>
                                                             </div>
                                                             <div
                                                                 className="max-h-[200px] overflow-y-auto space-y-2 p-2 border rounded-md">
                                                                 {filteredGroups.length === 0 ? (
                                                                     <div
                                                                         className="flex flex-col gap-4 w-full border-yellow-500 border p-4 rounded-md">
-                                                        <span
-                                                            className="text-sm ftext-foreground font-bold text-yellow-500">
-                                                            {t('warning')}
-                                                        </span>
+                                                                        <span
+                                                                            className="text-sm ftext-foreground font-bold text-yellow-500">
+                                                                            {t('warning')}
+                                                                        </span>
                                                                         <span
                                                                             className="text-sm font-medium text-foreground">
-                                                            <Trans i18nKey={'templates.groupsExistingWarning'}
-                                                                   components={{
-                                                                       a: (
-                                                                           <a
-                                                                               href="/groups"
-                                                                               className="font-bold text-primary hover:underline"
-                                                                               onClick={(e) => {
-                                                                                   e.preventDefault();
-                                                                                   navigate('/groups');
-                                                                               }}
-                                                                           />
-                                                                       )
-                                                                   }}
-                                                            >
-                                                            </Trans>
-                                                        </span>
+                                                                            <Trans i18nKey={'templates.groupsExistingWarning'}
+                                                                                components={{
+                                                                                    a: (
+                                                                                        <a
+                                                                                            href="/groups"
+                                                                                            className="font-bold text-primary hover:underline"
+                                                                                            onClick={(e) => {
+                                                                                                e.preventDefault();
+                                                                                                navigate('/groups');
+                                                                                            }}
+                                                                                        />
+                                                                                    )
+                                                                                }}
+                                                                            >
+                                                                            </Trans>
+                                                                        </span>
                                                                     </div>
                                                                 ) : (
                                                                     filteredGroups.map((group: any) => (
@@ -579,7 +579,7 @@ export default function UserTemplateModal({
                                                                 </div>
                                                             )}
                                                         </div>
-                                                        <FormMessage/>
+                                                        <FormMessage />
                                                     </FormItem>
                                                 );
                                             }}

--- a/dashboard/src/components/groups/Groups.tsx
+++ b/dashboard/src/components/groups/Groups.tsx
@@ -9,6 +9,7 @@ import { ScrollArea } from '@/components/ui/scroll-area'
 import { toast } from '@/hooks/use-toast'
 import { useTranslation } from 'react-i18next'
 import { queryClient } from '@/utils/query-client'
+import useDirDetection from '@/hooks/use-dir-detection'
 
 const initialDefaultValues: Partial<GroupFormValues> = {
   name: '',
@@ -25,7 +26,7 @@ export default function Groups({ isDialogOpen, onOpenChange }: GroupsProps) {
   const [editingGroup, setEditingGroup] = useState<GroupResponse | null>(null)
   const { t } = useTranslation()
   const modifyGroupMutation = useModifyGroup()
-  
+  const dir = useDirDetection()
   const { data: groupsData, isLoading } = useGetAllGroups({})
 
   const form = useForm<GroupFormValues>({
@@ -81,7 +82,7 @@ export default function Groups({ isDialogOpen, onOpenChange }: GroupsProps) {
   return (
     <div className="flex-1 w-full space-y-4 p-4 pt-6">
       <ScrollArea className="h-[calc(100vh-8rem)]">
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        <div dir={dir} className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
           {groupsData?.groups.map((group) => (
             <Group
               key={group.id}

--- a/dashboard/src/components/templates/UserTemplate.tsx
+++ b/dashboard/src/components/templates/UserTemplate.tsx
@@ -1,14 +1,14 @@
-import {useState} from "react";
-import {Card, CardDescription, CardTitle} from "../ui/card";
+import { useState } from "react";
+import { Card, CardDescription, CardTitle } from "../ui/card";
 import {
     DropdownMenu,
     DropdownMenuContent,
     DropdownMenuItem,
     DropdownMenuTrigger,
 } from "../ui/dropdown-menu";
-import {Button} from "../ui/button";
-import {Copy, EllipsisVertical, Infinity, Pen, Trash2} from "lucide-react";
-import {useTranslation} from "react-i18next";
+import { Button } from "../ui/button";
+import { Copy, EllipsisVertical, Infinity, Pen, Trash2 } from "lucide-react";
+import { useTranslation } from "react-i18next";
 import useDirDetection from "@/hooks/use-dir-detection";
 import {
     AlertDialog,
@@ -20,24 +20,24 @@ import {
     AlertDialogHeader,
     AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import {cn} from "@/lib/utils";
-import {useToast} from "@/hooks/use-toast";
-import {formatBytes} from "@/utils/formatByte";
-import {createUserTemplate, useRemoveUserTemplate, UserTemplateCreate, UserTemplateResponse} from "@/service/api";
-import {queryClient} from "@/utils/query-client.ts";
+import { cn } from "@/lib/utils";
+import { useToast } from "@/hooks/use-toast";
+import { formatBytes } from "@/utils/formatByte";
+import { createUserTemplate, useRemoveUserTemplate, UserTemplateCreate, UserTemplateResponse } from "@/service/api";
+import { queryClient } from "@/utils/query-client.ts";
 
 const DeleteAlertDialog = ({
-                               userTemplate,
-                               isOpen,
-                               onClose,
-                               onConfirm,
-                           }: {
+    userTemplate,
+    isOpen,
+    onClose,
+    onConfirm,
+}: {
     userTemplate: UserTemplateResponse;
     isOpen: boolean;
     onClose: () => void;
     onConfirm: () => void;
 }) => {
-    const {t} = useTranslation();
+    const { t } = useTranslation();
     const dir = useDirDetection();
 
     return (
@@ -48,7 +48,7 @@ const DeleteAlertDialog = ({
                         <AlertDialogTitle>{t("templates.deleteUserTemplateTitle")}</AlertDialogTitle>
                         <AlertDialogDescription>
                             <span dir={dir}
-                                  dangerouslySetInnerHTML={{__html: t("templates.deleteUserTemplatePrompt", {name: userTemplate.name})}}/>
+                                dangerouslySetInnerHTML={{ __html: t("templates.deleteUserTemplatePrompt", { name: userTemplate.name }) }} />
                         </AlertDialogDescription>
                     </AlertDialogHeader>
                     <AlertDialogFooter className={cn(dir === "rtl" && "sm:gap-x-2 sm:flex-row-reverse")}>
@@ -63,13 +63,13 @@ const DeleteAlertDialog = ({
     );
 };
 
-const UserTemplate = ({template, onEdit}: {
+const UserTemplate = ({ template, onEdit }: {
     template: UserTemplateResponse,
     onEdit: (userTemplate: UserTemplateResponse) => void
 }) => {
-    const {t} = useTranslation();
+    const { t } = useTranslation();
     const dir = useDirDetection();
-    const {toast} = useToast();
+    const { toast } = useToast();
     const removeUserTemplateMutation = useRemoveUserTemplate()
     const [isDeleteDialogOpen, setDeleteDialogOpen] = useState(false);
 
@@ -90,7 +90,7 @@ const UserTemplate = ({template, onEdit}: {
                 templateId: template.id
             });
             toast({
-                title: t("success", {defaultValue: "Success"}),
+                title: t("success", { defaultValue: "Success" }),
                 description: t("templates.deleteSuccess", {
                     name: template.name,
                     defaultValue: "Template «{name}» has been deleted successfully"
@@ -98,10 +98,10 @@ const UserTemplate = ({template, onEdit}: {
             });
             setDeleteDialogOpen(false);
             // Invalidate nodes queries
-            queryClient.invalidateQueries({queryKey: ['/api/user_templates']});
+            queryClient.invalidateQueries({ queryKey: ['/api/user_templates'] });
         } catch (error) {
             toast({
-                title: t("error", {defaultValue: "Error"}),
+                title: t("error", { defaultValue: "Error" }),
                 description: t("templates.deleteFailed", {
                     name: template.name,
                     defaultValue: "Failed to delete template «{name}»"
@@ -119,17 +119,17 @@ const UserTemplate = ({template, onEdit}: {
             }
             await createUserTemplate(newTemplate)
             toast({
-                title: t("success", {defaultValue: "Success"}),
+                title: t("success", { defaultValue: "Success" }),
                 description: t("templates.duplicateSuccess", {
                     name: template.name,
                     defaultValue: "Template «{name}» has been duplicated successfully"
                 })
             });
-            queryClient.invalidateQueries({queryKey: ['/api/user_templates']});
+            queryClient.invalidateQueries({ queryKey: ['/api/user_templates'] });
 
         } catch (error) {
             toast({
-                title: t("error", {defaultValue: "Error"}),
+                title: t("error", { defaultValue: "Error" }),
                 description: t("templates.duplicateFailed", {
                     name: template.name,
                     defaultValue: "Failed to duplicate template «{name}»"
@@ -152,14 +152,14 @@ const UserTemplate = ({template, onEdit}: {
                     <CardDescription>
                         <div className="flex flex-col gap-y-1 mt-2">
                             <p className={"flex items-center gap-x-1"}>
-                                {t("userDialog.dataLimit")}: <span>{(!template.data_limit || template.data_limit === 0) ?
-                                <Infinity
-                                    className="w-4 h-4"></Infinity> : formatBytes(template.data_limit ? template.data_limit : 0)}</span>
+                                {t("userDialog.dataLimit")}: <span dir="ltr">{(!template.data_limit || template.data_limit === 0) ?
+                                    <Infinity
+                                        className="w-4 h-4"></Infinity> : formatBytes(template.data_limit ? template.data_limit : 0)}</span>
                             </p>
                             <p className={"flex items-center gap-x-1"}>
-                                {t("Expire")}: <span>{(!template.expire_duration || template.expire_duration === 0 ?
-                                <Infinity
-                                    className="w-4 h-4"></Infinity> : `${template.expire_duration / 60 / 60 / 24} Days`)}</span>
+                                {t("expire")}: <span dir="ltr">{(!template.expire_duration || template.expire_duration === 0 ?
+                                    <Infinity
+                                        className="w-4 h-4"></Infinity> : `${template.expire_duration / 60 / 60 / 24} Days`)}</span>
                             </p>
                         </div>
                     </CardDescription>
@@ -171,7 +171,7 @@ const UserTemplate = ({template, onEdit}: {
                             size="icon"
                             className="template-dropdown-menu"
                         >
-                            <EllipsisVertical/>
+                            <EllipsisVertical />
                             <span className="sr-only">Template Actions</span>
                         </Button>
                     </DropdownMenuTrigger>
@@ -184,7 +184,7 @@ const UserTemplate = ({template, onEdit}: {
                                 onEdit(template);
                             }}
                         >
-                            <Pen className="h-4 w-4"/>
+                            <Pen className="h-4 w-4" />
                             <span>{t("edit")}</span>
                         </DropdownMenuItem>
                         <DropdownMenuItem
@@ -195,7 +195,7 @@ const UserTemplate = ({template, onEdit}: {
                                 handleDuplicate();
                             }}
                         >
-                            <Copy className="w-4 h-4"/>
+                            <Copy className="w-4 h-4" />
                             <span>{t("duplicate")}</span>
                         </DropdownMenuItem>
                         <DropdownMenuItem
@@ -206,7 +206,7 @@ const UserTemplate = ({template, onEdit}: {
                                 handleDeleteClick(e);
                             }}
                         >
-                            <Trash2 className="h-4 w-4 text-red-500"/>
+                            <Trash2 className="h-4 w-4 text-red-500" />
                             <span>{t("delete")}</span>
                         </DropdownMenuItem>
                     </DropdownMenuContent>

--- a/dashboard/src/pages/_dashboard._index.tsx
+++ b/dashboard/src/pages/_dashboard._index.tsx
@@ -63,7 +63,7 @@ export const nextPlanModelSchema = z.object({
 export const userCreateSchema = z.object({
   username: z.string().min(3).max(32),
   status: userStatusCreateEnum.optional(),
-  group_ids: z.array(z.number()).optional(),
+  group_ids: z.array(z.number()).min(1, { message: 'validation.required' }),
   data_limit: z.number().min(0),
   expire: z.union([z.string(), z.number(), z.null()]).optional(),
   note: z.string().optional(),

--- a/dashboard/src/pages/_dashboard._index.tsx
+++ b/dashboard/src/pages/_dashboard._index.tsx
@@ -86,7 +86,7 @@ const Dashboard = () => {
     defaultValues: {
       username: '',
       status: 'active',
-      data_limit: undefined,
+      data_limit: 0,
       expire: '',
       note: '',
       group_ids: [],
@@ -98,6 +98,7 @@ const Dashboard = () => {
     // Invalidate all relevant queries 
     queryClient.invalidateQueries({ queryKey: ['getUsers'] })
     queryClient.invalidateQueries({ queryKey: ['getUsersUsage'] })
+    queryClient.invalidateQueries({ queryKey: ['/api/users/'] })
   }
 
 


### PR DESCRIPTION
### Description

**This PR includes the following changes:**

- Improved dialog layouts and button spacing for better mobile usability.
- Fixed the data limit field to allow 0 as a default and to handle clearing/typing edge cases.
- Disabled the "Create" button in user and template dialogs if no groups are available, and added a clear warning with a link to the groups page (matching UI/UX between dialogs).
- Made `group_ids` a required field in the user creation schema, so at least one group must be selected to create a user.
- Ensured all validation and error messages are consistent and user-friendly.

**Commits:**
- `fix: fix dialogs behavior in mobile and data limit 0 default and disa…`
- `fix: make group required`
