### PR TITLE
fix(webhook): days left must not compare in range #1918

### DIFF
--- a/app/db/crud/user.py
+++ b/app/db/crud/user.py
@@ -313,7 +313,7 @@ async def get_days_left_reached_users(db: AsyncSession, days: int) -> list[User]
         .options(joinedload(User.notification_reminders))
         .where(User.status == UserStatus.active)
         .where(User.expire.isnot(None))
-        .where(User.days_left <= days)
+        .where(User.days_left == days)
         .where(not_(existing_reminder_subq))  # Only users without existing reminders
     )
 


### PR DESCRIPTION
When use `<=` for comparison, the days left may include more than one threshold set in webhook settings, and as reminders store in db, there will be no webhook call anymore if multiple threshold sets