### PR TITLE
fix: prevent zombie processes by waiting for child process termination

### DIFF
--- a/app/dashboard/__init__.py
+++ b/app/dashboard/__init__.py
@@ -32,7 +32,15 @@ def run_dev():
         cwd=base_dir
     )
 
-    atexit.register(proc.terminate)
+    def cleanup():
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+
+    atexit.register(cleanup)
 
 
 def run_build():

--- a/app/xray/core.py
+++ b/app/xray/core.py
@@ -140,6 +140,11 @@ class XRayCore:
             return
 
         self.process.terminate()
+        try:
+            self.process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            self.process.kill()
+            self.process.wait()
         self.process = None
         logger.warning("Xray core stopped")
 


### PR DESCRIPTION
## Problem
After stopping or restarting the application, zombie processes remain because `subprocess.Popen` child processes are terminated but never reaped with `wait()`.

## Solution
Added `wait()` calls after `terminate()` in:
- `app/xray/core.py`: `XRayCore.stop()` method
- `app/dashboard/__init__.py`: `run_dev()` cleanup handler

The fix includes:
1. Call `wait(timeout=5)` after `terminate()` to give the process time to exit gracefully
2. If the process doesn't exit within 5 seconds, call `kill()` followed by `wait()` to force termination

## Testing
- Verified that xray process is properly reaped after stopping
- Verified that npm dev process is properly reaped on application exit