### PR TITLE
fix: improve xray config parsing robustness and x25519 key extraction

### DIFF
--- a/app/xray/config.py
+++ b/app/xray/config.py
@@ -246,13 +246,19 @@ class XRayConfig(dict):
 
                         # core.get_x25519 may return None if the xray binary output format
                         # is different or the provided private key is invalid. Check before use.
-                        if x25519 and x25519.get('public_key'):
-                            settings['pbk'] = x25519['public_key']
-                        else:
+                        if not x25519:
                             raise ValueError(
                                 f"Could not derive publicKey from provided privateKey for {inbound['tag']}. "
                                 "Make sure the xray binary supports x25519 and the privateKey is valid, "
                                 "or provide publicKey explicitly in realitySettings.")
+
+                        derived_pbk = x25519.get('public_key') or x25519.get('publicKey')
+                        if not derived_pbk:
+                            raise ValueError(
+                                f"Xray x25519 output did not contain public key for {inbound['tag']}. "
+                                "Update xray core or provide publicKey explicitly in realitySettings.")
+
+                        settings['pbk'] = derived_pbk
 
                     try:
                         settings['sid'] = tls_settings.get('shortIds')[0]

--- a/app/xray/config.py
+++ b/app/xray/config.py
@@ -51,12 +51,33 @@ class XRayConfig(dict):
         self._apply_api()
 
     def _apply_api(self):
-        api_inbound = self.get_inbound("API_INBOUND")
-        if api_inbound:
-            api_inbound["listen"] = self.api_host
-            api_inbound["listen"]["address"] = self.api_host
-            api_inbound["port"] = self.api_port
-            return
+        # Normalize any existing API_INBOUND entry. Some configs may store
+        # inbounds in non-standard shapes (e.g. listen as a string). Find the
+        # inbound by tag and normalize/replace it safely.
+        for i, inbound in enumerate(self.get('inbounds', []) or []):
+            try:
+                tag = inbound.get('tag') if isinstance(inbound, dict) else None
+            except Exception:
+                tag = None
+
+            if tag == 'API_INBOUND':
+                # ensure we have a dict to work with
+                if not isinstance(inbound, dict):
+                    inbound = {}
+
+                # Normalize listen to a plain address string. Some configs may
+                # use a dict like {"address": "..."} or other shapes, but
+                # xray expects listen to be a string address. Always set it to
+                # the configured api_host so generated config is valid.
+                inbound['listen'] = self.api_host
+
+                inbound['port'] = self.api_port
+                # replace in the original list to ensure other code sees the change
+                try:
+                    self['inbounds'][i] = inbound
+                except Exception:
+                    pass
+                return
 
         self["api"] = {
             "services": [
@@ -206,10 +227,13 @@ class XRayConfig(dict):
                     settings['tls'] = 'reality'
                     settings['sni'] = tls_settings.get('serverNames', [])
 
-                    try:
-                        settings['pbk'] = tls_settings['publicKey']
-                    except KeyError:
-                        pvk = tls_settings.get('privateKey')
+                    # reality public key can be provided under different names depending on
+                    # xray core version / config style. Try several common keys first.
+                    pbk = tls_settings.get('publicKey') or tls_settings.get('public_key') or tls_settings.get('public-key')
+                    if pbk:
+                        settings['pbk'] = pbk
+                    else:
+                        pvk = tls_settings.get('privateKey') or tls_settings.get('private_key') or tls_settings.get('private-key')
                         if not pvk:
                             raise ValueError(
                                 f"You need to provide privateKey in realitySettings of {inbound['tag']}")
@@ -217,13 +241,18 @@ class XRayConfig(dict):
                         try:
                             from app.xray import core
                             x25519 = core.get_x25519(pvk)
-                            settings['pbk'] = x25519['public_key']
                         except ImportError:
-                            pass
+                            x25519 = None
 
-                        if not settings.get('pbk'):
+                        # core.get_x25519 may return None if the xray binary output format
+                        # is different or the provided private key is invalid. Check before use.
+                        if x25519 and x25519.get('public_key'):
+                            settings['pbk'] = x25519['public_key']
+                        else:
                             raise ValueError(
-                                f"You need to provide publicKey in realitySettings of {inbound['tag']}")
+                                f"Could not derive publicKey from provided privateKey for {inbound['tag']}. "
+                                "Make sure the xray binary supports x25519 and the privateKey is valid, "
+                                "or provide publicKey explicitly in realitySettings.")
 
                     try:
                         settings['sid'] = tls_settings.get('shortIds')[0]

--- a/app/xray/core.py
+++ b/app/xray/core.py
@@ -1,4 +1,5 @@
 import atexit
+import json
 import re
 import subprocess
 import threading
@@ -42,14 +43,76 @@ class XRayCore:
         cmd = [self.executable_path, "x25519"]
         if private_key:
             cmd.extend(['-i', private_key])
-        output = subprocess.check_output(cmd, stderr=subprocess.STDOUT).decode('utf-8')
-        m = re.match(r'Private key: (.+)\nPublic key: (.+)', output)
-        if m:
-            private, public = m.groups()
-            return {
-                "private_key": private,
-                "public_key": public
-            }
+        output = subprocess.check_output(cmd, stderr=subprocess.STDOUT).decode('utf-8', errors='ignore')
+
+        private, public = None, None
+        stripped = output.strip()
+
+        def _extract_from_obj(obj):
+            nonlocal private, public
+            if isinstance(obj, dict):
+                for key, value in obj.items():
+                    key_l = str(key).lower()
+                    if isinstance(value, (dict, list)):
+                        _extract_from_obj(value)
+                        continue
+                    if not isinstance(value, str):
+                        continue
+                    value = value.strip()
+                    if not value:
+                        continue
+                    if 'private' in key_l and 'key' in key_l and not private:
+                        private = value
+                    elif 'public' in key_l and 'key' in key_l and not public:
+                        public = value
+            elif isinstance(obj, list):
+                for item in obj:
+                    _extract_from_obj(item)
+
+        if stripped:
+            try:
+                parsed = json.loads(stripped)
+            except (json.JSONDecodeError, ValueError):
+                parsed = None
+            if parsed is not None:
+                _extract_from_obj(parsed)
+
+        if not (private or public):
+            pattern = re.compile(
+                r'(?i)(private|public)[_\s-]*key(?:\s*\(\w+\))?\s*(?:[:=]\s*|\s+is\s+)?([A-Za-z0-9+/=_-]+)'
+            )
+            for key_type, value in pattern.findall(output):
+                value = value.strip()
+                if not value:
+                    continue
+                if key_type.lower().startswith('private') and not private:
+                    private = value
+                elif key_type.lower().startswith('public') and not public:
+                    public = value
+
+        if not (private or public):
+            for line in output.splitlines():
+                lower = line.lower()
+                if 'key' not in lower:
+                    continue
+                match = re.search(r'([A-Za-z0-9+/=_-]{16,})', line)
+                if not match:
+                    continue
+                value = match.group(1).strip()
+                if not value:
+                    continue
+                if 'private' in lower and not private:
+                    private = value
+                elif 'public' in lower and not public:
+                    public = value
+
+        if private or public:
+            result = {}
+            if private:
+                result["private_key"] = private
+            if public:
+                result["public_key"] = public
+            return result
 
     def __capture_process_logs(self):
         def capture_and_debug_log():

--- a/tmp_test_load_xray_config.py
+++ b/tmp_test_load_xray_config.py
@@ -1,0 +1,136 @@
+import importlib.util
+import json
+import sys
+
+# Provide a lightweight shim for commentjson if not installed so we can
+# import the config module for a quick unit test without installing deps.
+if 'commentjson' not in sys.modules:
+    import types
+    shim = types.SimpleNamespace()
+    shim.loads = json.loads
+    sys.modules['commentjson'] = shim
+
+# Create minimal shims for modules that `config.py` imports from the package
+# so we can load it without installing the full application dependencies.
+if 'app.db' not in sys.modules:
+    import types
+    mod = types.ModuleType('app.db')
+    class DummyCtx:
+        def __enter__(self):
+            return None
+        def __exit__(self, exc_type, exc, tb):
+            return False
+    def GetDB():
+        return DummyCtx()
+    mod.GetDB = GetDB
+    # crud.get_users will not be used in our quick test, provide a stub
+    mod.crud = types.SimpleNamespace(get_users=lambda db, status=None: [])
+    sys.modules['app.db'] = mod
+
+if 'app.models.proxy' not in sys.modules:
+    import types
+    modp = types.ModuleType('app.models.proxy')
+    # Provide ProxyTypes minimal enum used in config
+    from enum import Enum
+    class ProxyTypes(str, Enum):
+        VMess = 'vmess'
+        VLESS = 'vless'
+        Trojan = 'trojan'
+        Shadowsocks = 'shadowsocks'
+    modp.ProxyTypes = ProxyTypes
+    # ProxySettings stub
+    class ProxySettings:
+        @classmethod
+        def from_dict(cls, proxy_type, d):
+            return d
+    modp.ProxySettings = ProxySettings
+    sys.modules['app.models.proxy'] = modp
+
+if 'app.models.user' not in sys.modules:
+    import types
+    modu = types.ModuleType('app.models.user')
+    class UserStatus:
+        active = 'active'
+        on_hold = 'on_hold'
+    modu.UserStatus = UserStatus
+    sys.modules['app.models.user'] = modu
+
+if 'app.utils.crypto' not in sys.modules:
+    import types
+    modc = types.ModuleType('app.utils.crypto')
+    def get_cert_SANs(cert):
+        return []
+    modc.get_cert_SANs = get_cert_SANs
+    sys.modules['app.utils.crypto'] = modc
+
+# shim top-level config module used by the project
+if 'config' not in sys.modules:
+    import types
+    confmod = types.ModuleType('config')
+    confmod.DEBUG = False
+    confmod.XRAY_EXCLUDE_INBOUND_TAGS = []
+    confmod.XRAY_FALLBACKS_INBOUND_TAG = None
+    sys.modules['config'] = confmod
+
+# load module directly without importing app package
+spec = importlib.util.spec_from_file_location('xray_config', r'c:\Users\evgen\Documents\GitHub\Marzban\app\xray\config.py')
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+XRayConfig = mod.XRayConfig
+
+# minimal config template
+base_config = {
+    "inbounds": [
+        {
+            "listen": "0.0.0.0",
+            "port": 10086,
+            "protocol": "vless",
+            "settings": {
+                "clients": []
+            },
+            "streamSettings": {
+                "network": "tcp",
+                "tcpSettings": {
+                    "header": {
+                        "type": "http",
+                        "request": {
+                            "path": ["/"],
+                            "headers": {"Host": ["example.com"]}
+                        }
+                    }
+                },
+                "security": "reality",
+                "realitySettings": {
+                    "serverNames": ["example.com"],
+                    "publicKey": "TEST_PUBLIC_KEY",
+                    "shortIds": ["abcd"]
+                }
+            },
+            "tag": "TEST_REALITY"
+        }
+    ],
+    "outbounds": [{"tag": "direct", "protocol": "freedom"}]
+}
+
+print('Case 1: publicKey provided under publicKey')
+conf = XRayConfig(json.dumps(base_config))
+print('-> inbounds parsed:', conf.inbounds)
+
+# case 2: publicKey missing, privateKey present (simulate get_x25519 returning None by not having xray binary)
+print('\nCase 2: privateKey provided, no publicKey')
+base_config['inbounds'][0]['streamSettings']['realitySettings'].pop('publicKey', None)
+base_config['inbounds'][0]['streamSettings']['realitySettings']['privateKey'] = 'TEST_PRIVATE_KEY'
+try:
+    conf2 = XRayConfig(json.dumps(base_config))
+    print('-> inbounds parsed:', conf2.inbounds)
+except Exception as e:
+    print('-> raised:', type(e).__name__, str(e))
+
+# case 3: neither key provided
+print('\nCase 3: neither publicKey nor privateKey provided')
+base_config['inbounds'][0]['streamSettings']['realitySettings'].pop('privateKey', None)
+try:
+    conf3 = XRayConfig(json.dumps(base_config))
+    print('-> inbounds parsed:', conf3.inbounds)
+except Exception as e:
+    print('-> raised:', type(e).__name__, str(e))


### PR DESCRIPTION
- normalize API_INBOUND handling to support non-standard config shapes
- support multiple naming conventions for reality public/private keys
- make x25519 key extraction more resilient to different xray output formats
- add fallback parsing strategies for JSON and regex-based key detection
- improve error messages when public key derivation fails