### PR TITLE
feat: Support new xray X25519 output format

### DIFF
--- a/app/xray/config.py
+++ b/app/xray/config.py
@@ -228,6 +228,8 @@ class XRayConfig(dict):
                         try:
                             from app.xray import core
                             x25519 = core.get_x25519(pvk)
+                            if not x25519:
+                                raise ValueError(f"Could not parse x25519 output from xray core for {inbound['tag']}")
                             settings['pbk'] = x25519['public_key']
                         except ImportError:
                             pass

--- a/app/xray/core.py
+++ b/app/xray/core.py
@@ -43,12 +43,22 @@ class XRayCore:
         if private_key:
             cmd.extend(['-i', private_key])
         output = subprocess.check_output(cmd, stderr=subprocess.STDOUT).decode('utf-8')
-        m = re.match(r'Private key: (.+)\nPublic key: (.+)', output)
-        if m:
-            private, public = m.groups()
+        data = {}
+        for line in output.splitlines():
+            if ": " in line:
+                key, value = line.split(": ", 1)
+                data[key.strip()] = value.strip()
+        
+        if "Private key" in data and "Public key" in data:
             return {
-                "private_key": private,
-                "public_key": public
+                "private_key": data["Private key"],
+                "public_key": data["Public key"]
+            }
+            
+        if "PrivateKey" in data and "Password" in data:
+            return {
+                "private_key": data["PrivateKey"],
+                "public_key": data["Password"]
             }
 
     def __capture_process_logs(self):

--- a/app/xray/core.py
+++ b/app/xray/core.py
@@ -45,20 +45,18 @@ class XRayCore:
         output = subprocess.check_output(cmd, stderr=subprocess.STDOUT).decode('utf-8')
         data = {}
         for line in output.splitlines():
-            if ": " in line:
-                key, value = line.split(": ", 1)
+            if ":" in line:
+                key, value = line.split(":", 1)
                 data[key.strip()] = value.strip()
         
-        if "Private key" in data and "Public key" in data:
+        keys_lower = {k.lower().replace(' ', ''): v for k, v in data.items()}
+        prv = keys_lower.get("privatekey")
+        pub = keys_lower.get("publickey") or keys_lower.get("password")
+        
+        if prv and pub:
             return {
-                "private_key": data["Private key"],
-                "public_key": data["Public key"]
-            }
-            
-        if "PrivateKey" in data and "Password" in data:
-            return {
-                "private_key": data["PrivateKey"],
-                "public_key": data["Password"]
+                "private_key": prv,
+                "public_key": pub
             }
 
     def __capture_process_logs(self):


### PR DESCRIPTION
The xray x25519 command in newer versions (e.g. v25.3.6+) changed its output format.

Old Format:
```
Private key: ...
Public key: ...
```
New Format:
```
PrivateKey: ...
Password: ...
Hash32: ...
```
(where Password corresponds to the public key)

I updated `app/xray/core.py` to robustly parse the output by converting lines into a key-value dictionary. This avoids potential regex issues and correctly detects which format is present by checking for the specific keys (Private key/Public key vs PrivateKey/Password).

Closes #1938
