### PR TITLE
feat: add user-facing Telegram bot with trial, payments and referrals

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,16 @@ UVICORN_PORT = 8000
 # TELEGRAM_DEFAULT_VLESS_FLOW = "xtls-rprx-vision"
 # TELEGRAM_PROXY_URL = "http://localhost:8080"
 
+## User-facing bot (separate token from @BotFather)
+# TELEGRAM_USER_BOT_TOKEN = 987654321:BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB
+## Trial account settings
+# USER_BOT_TRIAL_DAYS = 3
+# USER_BOT_TRIAL_GB = 3
+## Telegram Stars prices (leave default or customise)
+# USER_BOT_STARS_1M = 100
+# USER_BOT_STARS_3M = 280
+# USER_BOT_STARS_6M = 520
+
 # DISCORD_WEBHOOK_URL = "https://discord.com/api/webhooks/xxxxxxx"
 
 # CUSTOM_TEMPLATES_DIRECTORY="/var/lib/marzban/templates/"

--- a/app/db/__init__.py
+++ b/app/db/__init__.py
@@ -31,7 +31,10 @@ from .crud import (create_admin, create_notification_reminder,  # noqa
                    get_users_count, remove_admin, remove_user, revoke_user_sub,
                    set_owner, update_admin, update_user, update_user_status, reset_user_by_next,
                    update_user_sub, start_user_expire, get_admin_by_id,
-                   get_admin_by_telegram_id)
+                   get_admin_by_telegram_id,
+                   get_user_by_telegram_id, get_user_by_referral_code,
+                   link_user_telegram_id, set_user_referral_code,
+                   record_referral, extend_user_expire, count_user_referrals)
 
 from .models import JWT, System, User  # noqa
 
@@ -60,6 +63,15 @@ __all__ = [
     "get_admins",
     "get_admin_by_id",
     "get_admin_by_telegram_id",
+
+    # user-bot
+    "get_user_by_telegram_id",
+    "get_user_by_referral_code",
+    "link_user_telegram_id",
+    "set_user_referral_code",
+    "record_referral",
+    "extend_user_expire",
+    "count_user_referrals",
 
     "create_notification_reminder",
     "get_notification_reminder",

--- a/app/db/crud.py
+++ b/app/db/crud.py
@@ -1498,3 +1498,123 @@ def count_online_users(db: Session, hours: int = 24):
     query = db.query(func.count(User.id)).filter(User.online_at.isnot(
         None), User.online_at >= twenty_four_hours_ago)
     return query.scalar()
+
+
+# ---------------------------------------------------------------------------
+# User-bot specific CRUD helpers
+# ---------------------------------------------------------------------------
+
+def get_user_by_telegram_id(db: Session, telegram_id: int) -> Optional[User]:
+    """Retrieve a Marzban user linked to the given Telegram user ID."""
+    return get_user_queryset(db).filter(User.telegram_id == telegram_id).first()
+
+
+def get_user_by_referral_code(db: Session, referral_code: str) -> Optional[User]:
+    """Retrieve a Marzban user by their referral code."""
+    return get_user_queryset(db).filter(User.referral_code == referral_code).first()
+
+
+def link_user_telegram_id(db: Session, dbuser: User, telegram_id: int) -> User:
+    """Attach a Telegram user ID to an existing Marzban user account."""
+    dbuser.telegram_id = telegram_id
+    db.commit()
+    db.refresh(dbuser)
+    return dbuser
+
+
+def set_user_referral_code(db: Session, dbuser: User, code: str) -> User:
+    """Assign a referral code to a user (idempotent – skips if already set)."""
+    if not dbuser.referral_code:
+        dbuser.referral_code = code
+        db.commit()
+        db.refresh(dbuser)
+    return dbuser
+
+
+def count_rewarded_referrals(db: Session, referrer: User) -> int:
+    """
+    Count how many of this user's referrals have already triggered a bonus payout.
+    A referral is "rewarded" when referred_by_id is set on the invited user.
+    """
+    return (
+        db.query(func.count(User.id))
+        .filter(User.referred_by_id == referrer.id)
+        .scalar() or 0
+    )
+
+
+def record_referral(db: Session, new_user: User, referrer: User) -> bool:
+    """
+    Record that *new_user* was referred by *referrer* and, if the referrer has
+    not yet hit their cap, award them USER_BOT_REFERRAL_BONUS_DAYS extra days.
+
+    Returns True when a bonus was actually credited, False when the cap was
+    already reached or the bonus is deferred (REQUIRE_PAYMENT mode).
+
+    Protection against farming:
+      • USER_BOT_REFERRAL_MAX_BONUS_DAYS  – hard cap on total bonus days
+        (0 = unlimited).  Checked BEFORE applying this referral so an attacker
+        with 100 fake accounts can earn at most MAX days, not infinite.
+      • The function is idempotent: calling it twice for the same new_user has
+        no effect because new_user.referred_by_id will already be set on the
+        second call (the caller guards this, but we double-check here too).
+    """
+    from config import (
+        USER_BOT_REFERRAL_BONUS_DAYS,
+        USER_BOT_REFERRAL_MAX_BONUS_DAYS,
+        USER_BOT_REFERRAL_REQUIRE_PAYMENT,
+    )
+
+    # Idempotency guard
+    if new_user.referred_by_id is not None:
+        return False
+
+    # Always record the relationship, regardless of bonus eligibility
+    new_user.referred_by_id = referrer.id
+    db.flush()  # write referred_by_id without full commit yet
+
+    if USER_BOT_REFERRAL_REQUIRE_PAYMENT:
+        # Bonus deferred – will be applied when the referral makes their first payment
+        db.commit()
+        return False
+
+    # Check the hard cap: how many bonus days has the referrer already accumulated?
+    if USER_BOT_REFERRAL_MAX_BONUS_DAYS > 0:
+        already_rewarded_referrals = count_rewarded_referrals(db, referrer)
+        # The current new_user is already counted (referred_by_id was flushed above),
+        # so subtract 1 to get the count BEFORE this referral
+        prior_referrals = already_rewarded_referrals - 1
+        total_bonus_so_far = prior_referrals * USER_BOT_REFERRAL_BONUS_DAYS
+        if total_bonus_so_far >= USER_BOT_REFERRAL_MAX_BONUS_DAYS:
+            db.commit()
+            return False  # cap reached – relationship recorded, no days added
+
+    # Award the bonus
+    now_ts = int(datetime.utcnow().timestamp())
+    current_expire = referrer.expire or now_ts
+    referrer.expire = max(current_expire, now_ts) + USER_BOT_REFERRAL_BONUS_DAYS * 24 * 3600
+
+    db.commit()
+    return True
+
+
+def extend_user_expire(db: Session, dbuser: User, days: int) -> User:
+    """
+    Extend (or set) *dbuser*'s expiry by *days* calendar days.
+
+    If the account is already expired, the extension starts from *now*.
+    """
+    now_ts = int(datetime.utcnow().timestamp())
+    current_expire = dbuser.expire or 0
+    base = max(current_expire, now_ts)
+    dbuser.expire = base + days * 24 * 3600
+    if dbuser.status in (UserStatus.expired, UserStatus.limited):
+        dbuser.status = UserStatus.active
+    db.commit()
+    db.refresh(dbuser)
+    return dbuser
+
+
+def count_user_referrals(db: Session, dbuser: User) -> int:
+    """Return how many users were referred by *dbuser*."""
+    return db.query(func.count(User.id)).filter(User.referred_by_id == dbuser.id).scalar() or 0

--- a/app/db/migrations/versions/a1b2c3d4e5f6_user_bot_fields.py
+++ b/app/db/migrations/versions/a1b2c3d4e5f6_user_bot_fields.py
@@ -1,0 +1,45 @@
+"""user_bot_fields
+
+Revision ID: a1b2c3d4e5f6
+Revises: 07f9bbb3db4e
+Create Date: 2026-03-01 12:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'a1b2c3d4e5f6'
+down_revision = '07f9bbb3db4e'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column('users', sa.Column('telegram_id', sa.BigInteger(), nullable=True))
+    op.add_column('users', sa.Column('referral_code', sa.String(16), nullable=True))
+    op.add_column('users', sa.Column('referred_by_id', sa.Integer(), nullable=True))
+
+    try:
+        op.create_unique_constraint('uq_users_telegram_id', 'users', ['telegram_id'])
+        op.create_unique_constraint('uq_users_referral_code', 'users', ['referral_code'])
+        op.create_foreign_key(
+            'fk_users_referred_by_id', 'users', 'users',
+            ['referred_by_id'], ['id']
+        )
+    except Exception:
+        # SQLite doesn't support all constraints via ALTER TABLE
+        pass
+
+
+def downgrade() -> None:
+    try:
+        op.drop_constraint('fk_users_referred_by_id', 'users', type_='foreignkey')
+        op.drop_constraint('uq_users_referral_code', 'users', type_='unique')
+        op.drop_constraint('uq_users_telegram_id', 'users', type_='unique')
+    except Exception:
+        pass
+    op.drop_column('users', 'referred_by_id')
+    op.drop_column('users', 'referral_code')
+    op.drop_column('users', 'telegram_id')

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -95,6 +95,12 @@ class User(Base):
     edit_at = Column(DateTime, nullable=True, default=None)
     last_status_change = Column(DateTime, default=datetime.utcnow, nullable=True)
 
+    # User bot fields
+    telegram_id = Column(BigInteger, nullable=True, unique=True, default=None)
+    referral_code = Column(String(16), nullable=True, unique=True, default=None)
+    referred_by_id = Column(Integer, ForeignKey("users.id"), nullable=True, default=None)
+    referrals = relationship("User", foreign_keys="User.referred_by_id", backref="referred_by", lazy="dynamic")
+
     next_plan = relationship(
         "NextPlan",
         uselist=False,

--- a/app/telegram/__init__.py
+++ b/app/telegram/__init__.py
@@ -1,7 +1,7 @@
 import importlib.util
 from os.path import dirname
 from threading import Thread
-from config import TELEGRAM_API_TOKEN, TELEGRAM_PROXY_URL
+from config import TELEGRAM_API_TOKEN, TELEGRAM_PROXY_URL, TELEGRAM_USER_BOT_TOKEN
 from app import app
 from telebot import TeleBot, apihelper
 
@@ -26,6 +26,16 @@ def start_bot():
 
         thread = Thread(target=bot.infinity_polling, daemon=True)
         thread.start()
+
+    # ── User-facing bot ──────────────────────────────────────────────────────
+    if TELEGRAM_USER_BOT_TOKEN:
+        from app.telegram.user_bot_instance import user_bot
+        if user_bot:
+            # Import handlers so they register themselves on user_bot
+            from app.telegram.handlers import user_bot as _user_bot_handlers  # noqa: F401
+
+            thread = Thread(target=user_bot.infinity_polling, daemon=True)
+            thread.start()
 
 
 from .handlers.report import (  # noqa

--- a/app/telegram/handlers/user_bot.py
+++ b/app/telegram/handlers/user_bot.py
@@ -1,0 +1,571 @@
+"""
+User-facing Telegram bot handlers.
+
+Registered on the separate `user_bot` TeleBot instance (TELEGRAM_USER_BOT_TOKEN).
+Does NOT touch the admin bot (`bot`) and does NOT require is_admin=True.
+
+Features:
+  • /start [ref_CODE]   – register trial or show main menu
+  • Личный кабинет      – subscription status, traffic, expiry
+  • Мой конфиг          – subscription URL + QR code
+  • Продлить            – pay with Telegram Stars (1 / 3 / 6 months)
+  • Реферальная         – referral link and stats
+"""
+from __future__ import annotations
+
+import io
+import logging
+import secrets
+import string
+from datetime import datetime, timedelta
+
+import qrcode  # type: ignore[import-untyped]
+from sqlalchemy.exc import IntegrityError
+
+from app.db import GetDB, crud
+from app.models.user import UserCreate, UserResponse
+from app.telegram.user_bot_instance import user_bot
+from app.telegram.utils.user_bot_keyboards import UserBotKeyboard
+from app.utils.system import readable_size
+from config import (
+    USER_BOT_REFERRAL_BONUS_DAYS,
+    USER_BOT_REFERRAL_MAX_BONUS_DAYS,
+    USER_BOT_REFERRAL_REQUIRE_PAYMENT,
+    USER_BOT_STARS_1M,
+    USER_BOT_STARS_3M,
+    USER_BOT_STARS_6M,
+    USER_BOT_TRIAL_DAYS,
+    USER_BOT_TRIAL_GB,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Module-level cache for bot username (avoids get_me() on every referral press)
+# ---------------------------------------------------------------------------
+_bot_username: str | None = None
+
+
+def _get_bot_username() -> str:
+    global _bot_username
+    if _bot_username is None:
+        _bot_username = user_bot.get_me().username
+    return _bot_username
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_REF_ALPHABET = string.ascii_letters + string.digits
+
+
+def _gen_referral_code(length: int = 8) -> str:
+    return "".join(secrets.choice(_REF_ALPHABET) for _ in range(length))
+
+
+def _unique_referral_code(db) -> str:
+    """Generate a referral code that doesn't yet exist in the DB."""
+    for _ in range(20):
+        code = _gen_referral_code()
+        if not crud.get_user_by_referral_code(db, code):
+            return code
+    raise RuntimeError("Could not generate unique referral code")
+
+
+def _sanitize_username(first_name: str, tg_id: int) -> str:
+    """Build a valid Marzban username from Telegram first_name + id."""
+    safe = "".join(c for c in first_name.lower() if c.isalnum() or c in "-_")
+    safe = safe[:16] or "user"
+    return f"{safe}_{tg_id}"[-32:]
+
+
+def _build_proxies_and_inbounds() -> tuple[dict, dict]:
+    """Return (proxies_dict, inbounds_dict) with all currently active inbounds."""
+    from app import xray
+    from app.models.proxy import ProxyTypes
+    from config import TELEGRAM_DEFAULT_VLESS_FLOW
+
+    inbounds: dict[str, list[str]] = {}
+    proxies: dict = {}
+
+    for protocol, ibs in xray.config.inbounds_by_protocol.items():
+        tags = [ib["tag"] for ib in ibs]
+        if not tags:
+            continue
+        inbounds[protocol] = tags
+        extra = {}
+        if protocol == ProxyTypes.VLESS and TELEGRAM_DEFAULT_VLESS_FLOW:
+            extra["flow"] = TELEGRAM_DEFAULT_VLESS_FLOW
+        proxies[protocol] = extra
+
+    return proxies, inbounds
+
+
+def _grant_referral_bonus(db, referrer) -> bool:
+    """
+    Award USER_BOT_REFERRAL_BONUS_DAYS to *referrer* if they haven't hit the cap.
+    Used in REQUIRE_PAYMENT mode. Returns True if days were actually added.
+    """
+    already = crud.count_user_referrals(db, referrer)
+    if USER_BOT_REFERRAL_MAX_BONUS_DAYS > 0:
+        if already * USER_BOT_REFERRAL_BONUS_DAYS >= USER_BOT_REFERRAL_MAX_BONUS_DAYS:
+            return False
+
+    now_ts = int(datetime.utcnow().timestamp())
+    current_expire = referrer.expire or now_ts
+    referrer.expire = max(current_expire, now_ts) + USER_BOT_REFERRAL_BONUS_DAYS * 24 * 3600
+    db.commit()
+    return True
+
+
+def _get_or_create_user(db, tg_user, referral_code: str | None = None):
+    """
+    Return the existing Marzban user linked to *tg_user.id*, or create a
+    brand-new trial account.
+
+    Returns (db_user, is_new: bool).
+    Raises nothing – all errors are caught and logged.
+    """
+    existing = crud.get_user_by_telegram_id(db, tg_user.id)
+    if existing:
+        return existing, False
+
+    # ── Create trial account ────────────────────────────────────────────────
+    from app import xray
+
+    proxies, inbounds = _build_proxies_and_inbounds()
+    if not proxies:
+        logger.warning("user_bot: no inbounds in xray config, creating user without proxies")
+
+    username = _sanitize_username(tg_user.first_name or "user", tg_user.id)
+    base = username
+    suffix = 0
+    while crud.get_user(db, username):
+        suffix += 1
+        username = f"{base[:28]}_{suffix}"
+
+    # Expire at midnight UTC + TRIAL_DAYS
+    expire_ts = int(
+        (datetime.utcnow().replace(hour=0, minute=0, second=0, microsecond=0)
+         + timedelta(days=USER_BOT_TRIAL_DAYS)).timestamp()
+    )
+    data_limit_bytes = USER_BOT_TRIAL_GB * 1024 ** 3
+
+    new_user_schema = UserCreate(
+        username=username,
+        status="active",
+        expire=expire_ts,
+        data_limit=data_limit_bytes,
+        proxies=proxies,
+        inbounds=inbounds,
+    )
+
+    sudo_admin = None
+    for adm in crud.get_admins(db):
+        if adm.is_sudo:
+            sudo_admin = adm
+            break
+
+    # FIX #2: handle IntegrityError (race condition – two /start at same time)
+    try:
+        db_user = crud.create_user(db, new_user_schema, admin=sudo_admin)
+    except IntegrityError:
+        db.rollback()
+        # Another request won the race; return what's already in DB
+        existing = crud.get_user_by_telegram_id(db, tg_user.id)
+        if existing:
+            return existing, False
+        raise  # unexpected – re-raise for logging
+
+    crud.link_user_telegram_id(db, db_user, tg_user.id)
+    crud.set_user_referral_code(db, db_user, _unique_referral_code(db))
+
+    # Handle referral reward
+    if referral_code:
+        referrer = crud.get_user_by_referral_code(db, referral_code)
+        if referrer and referrer.id != db_user.id:
+            bonus_granted = crud.record_referral(db, db_user, referrer)
+            _notify_referrer(referrer, bonus_granted)
+
+    # Add to Xray core
+    try:
+        xray.operations.add_user(db_user)
+    except Exception as exc:
+        logger.error("user_bot: xray.operations.add_user failed: %s", exc)
+
+    return db_user, True
+
+
+def _notify_referrer(referrer, bonus_granted: bool) -> None:
+    """Send a Telegram notification to referrer. Silently skips if no telegram_id."""
+    if not referrer.telegram_id:
+        return
+    try:
+        if bonus_granted:
+            user_bot.send_message(
+                referrer.telegram_id,
+                f"🎉 По вашей реферальной ссылке зарегистрировался новый пользователь!\n"
+                f"Ваша подписка продлена на <b>{USER_BOT_REFERRAL_BONUS_DAYS} дней</b>.",
+                parse_mode="HTML",
+            )
+        elif USER_BOT_REFERRAL_REQUIRE_PAYMENT:
+            user_bot.send_message(
+                referrer.telegram_id,
+                f"👥 По вашей ссылке зарегистрировался новый пользователь.\n"
+                f"<b>+{USER_BOT_REFERRAL_BONUS_DAYS} дней</b> будут начислены "
+                f"после его первой оплаты.",
+                parse_mode="HTML",
+            )
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Formatting helpers
+# ---------------------------------------------------------------------------
+
+_STATUS_EMOJI = {
+    "active":   "✅",
+    "expired":  "🕰",
+    "limited":  "📵",
+    "disabled": "❌",
+    "on_hold":  "⏸",
+}
+
+
+def _account_text(db_user) -> str:
+    """
+    Build an HTML status string from a DB user object.
+    Must be called while the SQLAlchemy session is still open (db_user attached).
+    """
+    user = UserResponse.model_validate(db_user)
+
+    status_icon = _STATUS_EMOJI.get(user.status, "❓")
+    data_limit  = readable_size(user.data_limit) if user.data_limit else "Безлимит"
+    used        = readable_size(user.used_traffic) if user.used_traffic else "0 B"
+
+    if user.data_limit:
+        remaining = max(0, user.data_limit - user.used_traffic)
+        data_line = (
+            f"📊 Трафик: <code>{used}</code> / <code>{data_limit}</code>"
+            f"  (осталось <code>{readable_size(remaining)}</code>)"
+        )
+    else:
+        data_line = f"📊 Трафик: <code>{used}</code> / <code>{data_limit}</code>"
+
+    if user.expire:
+        exp_dt    = datetime.fromtimestamp(user.expire)
+        days_left = max(0, (exp_dt - datetime.now()).days)
+        exp_line  = f"📅 Истекает: <code>{exp_dt.date()}</code>  (осталось дней: <code>{days_left}</code>)"
+    else:
+        exp_line = "📅 Истекает: <code>никогда</code>"
+
+    return (
+        f"{status_icon} <b>Статус:</b> <code>{user.status}</code>\n\n"
+        f"👤 <b>Аккаунт:</b> <code>{user.username}</code>\n"
+        f"{data_line}\n"
+        f"{exp_line}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# /start
+# ---------------------------------------------------------------------------
+
+@user_bot.message_handler(commands=["start"])
+def cmd_start(message):
+    args = message.text.split(maxsplit=1)
+    ref_code: str | None = None
+    if len(args) > 1 and args[1].startswith("ref_"):
+        ref_code = args[1][4:]
+
+    tg_user = message.from_user
+
+    # FIX #1: build reply text INSIDE the session so db_user is still attached
+    with GetDB() as db:
+        try:
+            db_user, is_new = _get_or_create_user(db, tg_user, ref_code)
+        except Exception as exc:
+            logger.exception("user_bot: failed to get/create user for %s: %s", tg_user.id, exc)
+            user_bot.reply_to(message, "⚠️ Произошла ошибка. Попробуйте позже.")
+            return
+
+        if is_new:
+            text = (
+                f"👋 Привет, <b>{tg_user.first_name}</b>!\n\n"
+                f"Для вас создан пробный аккаунт:\n"
+                f"  • <b>{USER_BOT_TRIAL_DAYS} дней</b>\n"
+                f"  • <b>{USER_BOT_TRIAL_GB} ГБ</b> трафика\n\n"
+                f"Нажмите <b>«Мой конфиг»</b>, чтобы получить настройки подключения."
+            )
+        else:
+            text = f"👋 С возвращением, <b>{tg_user.first_name}</b>!\n\n" + _account_text(db_user)
+
+    user_bot.send_message(
+        message.chat.id,
+        text,
+        parse_mode="HTML",
+        reply_markup=UserBotKeyboard.main_menu(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Callback query router
+# ---------------------------------------------------------------------------
+
+@user_bot.callback_query_handler(func=lambda c: c.data.startswith("ub:"))
+def cb_router(call):
+    tg_id  = call.from_user.id
+    parts  = call.data.split(":")
+    action = parts[1] if len(parts) > 1 else ""
+
+    # FIX #4: single DB session for the whole handler; build text inside it
+    with GetDB() as db:
+        db_user = crud.get_user_by_telegram_id(db, tg_id)
+
+        if db_user is None:
+            user_bot.answer_callback_query(
+                call.id, "❌ Аккаунт не найден. Напишите /start", show_alert=True
+            )
+            return
+
+        # ── Main menu ────────────────────────────────────────────────────────
+        if action == "menu":
+            user_bot.answer_callback_query(call.id)
+            user_bot.edit_message_text(
+                f"👤 <b>Главное меню</b>\n\n{_account_text(db_user)}",
+                call.message.chat.id,
+                call.message.message_id,
+                parse_mode="HTML",
+                reply_markup=UserBotKeyboard.main_menu(),
+            )
+
+        # ── Personal cabinet ─────────────────────────────────────────────────
+        elif action == "cabinet":
+            user_bot.answer_callback_query(call.id)
+            user_bot.edit_message_text(
+                f"👤 <b>Личный кабинет</b>\n\n{_account_text(db_user)}",
+                call.message.chat.id,
+                call.message.message_id,
+                parse_mode="HTML",
+                reply_markup=UserBotKeyboard.back_to_menu(),
+            )
+
+        # ── Config menu ──────────────────────────────────────────────────────
+        elif action == "config":
+            user_bot.answer_callback_query(call.id)
+            user_bot.edit_message_text(
+                "📱 <b>Мой конфиг</b>\n\nВыберите формат:",
+                call.message.chat.id,
+                call.message.message_id,
+                parse_mode="HTML",
+                reply_markup=UserBotKeyboard.config_menu(),
+            )
+
+        # ── Subscription URL ─────────────────────────────────────────────────
+        elif action == "sub_url":
+            user_bot.answer_callback_query(call.id)
+            user = UserResponse.model_validate(db_user)
+            user_bot.edit_message_text(
+                f"🔗 <b>Ссылка подписки</b>\n\n"
+                f"<code>{user.subscription_url}</code>\n\n"
+                f"Скопируйте ссылку и добавьте её в ваш клиент (Happ, v2rayNG, Nekoray и т.д.).",
+                call.message.chat.id,
+                call.message.message_id,
+                parse_mode="HTML",
+                reply_markup=UserBotKeyboard.back_to_menu(),
+            )
+
+        # ── QR code ──────────────────────────────────────────────────────────
+        elif action == "qr":
+            user_bot.answer_callback_query(call.id, "Генерирую QR-код…")
+            user = UserResponse.model_validate(db_user)
+            with io.BytesIO() as buf:
+                qr = qrcode.QRCode(border=6)
+                qr.add_data(user.subscription_url)
+                qr.make_image().save(buf)
+                buf.seek(0)
+                user_bot.send_photo(
+                    call.message.chat.id,
+                    photo=buf,
+                    caption=(
+                        f"📷 <b>QR-код подписки</b>\n\n"
+                        f"<code>{user.subscription_url}</code>"
+                    ),
+                    parse_mode="HTML",
+                    reply_markup=UserBotKeyboard.back_to_menu(),
+                )
+
+        # ── Buy / extend ─────────────────────────────────────────────────────
+        elif action == "buy":
+            user_bot.answer_callback_query(call.id)
+            user_bot.edit_message_text(
+                "💎 <b>Продление подписки</b>\n\n"
+                "Оплата производится через <b>Telegram Stars</b> ⭐.\n"
+                "Выберите срок:",
+                call.message.chat.id,
+                call.message.message_id,
+                parse_mode="HTML",
+                reply_markup=UserBotKeyboard.buy_menu(),
+            )
+
+        elif action == "pay":
+            _stars_map  = {30: USER_BOT_STARS_1M, 90: USER_BOT_STARS_3M, 180: USER_BOT_STARS_6M}
+            _months_map = {30: "1 месяц", 90: "3 месяца", 180: "6 месяцев"}
+            try:
+                days = int(parts[2])
+            except (IndexError, ValueError):
+                user_bot.answer_callback_query(call.id, "Неверный параметр")
+                return
+            stars  = _stars_map.get(days, USER_BOT_STARS_1M)
+            months = _months_map.get(days, f"{days} дней")
+            user_bot.answer_callback_query(call.id)
+            user_bot.edit_message_text(
+                f"💎 <b>Подтверждение оплаты</b>\n\n"
+                f"Срок: <b>{months}</b>\n"
+                f"Стоимость: <b>{stars} ⭐</b>\n\n"
+                f"Нажмите кнопку ниже, чтобы оплатить:",
+                call.message.chat.id,
+                call.message.message_id,
+                parse_mode="HTML",
+                reply_markup=UserBotKeyboard.pay_confirm(days, stars),
+            )
+
+        elif action == "pay_confirm":
+            try:
+                days  = int(parts[2])
+                stars = int(parts[3])
+            except (IndexError, ValueError):
+                user_bot.answer_callback_query(call.id, "Неверный параметр")
+                return
+            user_bot.answer_callback_query(call.id)
+            user_bot.send_invoice(
+                chat_id=call.message.chat.id,
+                title=f"VPN подписка на {days} дней",
+                description=f"Продление VPN-подписки на {days} календарных дней",
+                invoice_payload=f"extend:{days}:{tg_id}",
+                provider_token="",   # empty string = Telegram Stars
+                currency="XTR",
+                prices=[{"label": f"{days} дней", "amount": stars}],
+            )
+
+        # ── Referral ─────────────────────────────────────────────────────────
+        elif action == "referral":
+            user_bot.answer_callback_query(call.id)
+            ref_count  = crud.count_user_referrals(db, db_user)
+            ref_code   = db_user.referral_code or "—"
+            # FIX #5: cached, no network call per click
+            ref_link   = f"https://t.me/{_get_bot_username()}?start=ref_{ref_code}"
+
+            earned_days = ref_count * USER_BOT_REFERRAL_BONUS_DAYS
+            if USER_BOT_REFERRAL_MAX_BONUS_DAYS > 0:
+                remaining_cap = max(0, USER_BOT_REFERRAL_MAX_BONUS_DAYS - earned_days)
+                cap_line = (
+                    f"📈 Заработано бонусов: <b>{earned_days} дн.</b> "
+                    f"из <b>{USER_BOT_REFERRAL_MAX_BONUS_DAYS} дн.</b> максимум\n"
+                    f"💡 Ещё доступно: <b>{remaining_cap} дн.</b>"
+                )
+            else:
+                cap_line = f"📈 Заработано бонусов: <b>{earned_days} дн.</b>"
+
+            payment_note = (
+                "\n\n⚠️ Бонус начисляется после первой оплаты приглашённого."
+                if USER_BOT_REFERRAL_REQUIRE_PAYMENT else ""
+            )
+
+            user_bot.edit_message_text(
+                f"👥 <b>Реферальная программа</b>\n\n"
+                f"За каждого приглашённого друга вы получаете "
+                f"<b>+{USER_BOT_REFERRAL_BONUS_DAYS} дней</b> к подписке."
+                f"{payment_note}\n\n"
+                f"🔗 Ваша реферальная ссылка:\n<code>{ref_link}</code>\n\n"
+                f"👤 Приглашено пользователей: <b>{ref_count}</b>\n"
+                f"{cap_line}",
+                call.message.chat.id,
+                call.message.message_id,
+                parse_mode="HTML",
+                reply_markup=UserBotKeyboard.referral_menu(),
+            )
+
+        else:
+            user_bot.answer_callback_query(call.id, "Неизвестная команда")
+
+
+# ---------------------------------------------------------------------------
+# Pre-checkout (must answer within 10 s)
+# ---------------------------------------------------------------------------
+
+@user_bot.pre_checkout_query_handler(func=lambda q: True)
+def pre_checkout(query):
+    user_bot.answer_pre_checkout_query(query.id, ok=True)
+
+
+# ---------------------------------------------------------------------------
+# Successful payment
+# ---------------------------------------------------------------------------
+
+@user_bot.message_handler(content_types=["successful_payment"])
+def successful_payment(message):
+    payload = message.successful_payment.invoice_payload  # "extend:<days>:<tg_id>"
+    try:
+        _, days_str, tg_id_str = payload.split(":")
+        days   = int(days_str)
+        tg_id  = int(tg_id_str)
+    except Exception:
+        logger.error("user_bot: bad invoice payload: %s", payload)
+        return
+
+    # FIX #1: build reply text INSIDE the session
+    with GetDB() as db:
+        db_user = crud.get_user_by_telegram_id(db, tg_id)
+        if not db_user:
+            logger.error("user_bot: payment for unknown tg_id %s", tg_id)
+            return
+
+        crud.extend_user_expire(db, db_user, days)
+        # Reload after update so _account_text sees fresh data
+        db_user = crud.get_user_by_telegram_id(db, tg_id)
+
+        # Deferred referral bonus (REQUIRE_PAYMENT mode)
+        if USER_BOT_REFERRAL_REQUIRE_PAYMENT and db_user.referred_by_id:
+            referrer = crud.get_user_by_id(db, db_user.referred_by_id)
+            if referrer:
+                sentinel = f"[ref_paid:{referrer.id}]"
+                note = db_user.note or ""
+                if sentinel not in note:
+                    db_user.note = (note + sentinel)[-500:]
+                    db.commit()
+                    bonus_granted = _grant_referral_bonus(db, referrer)
+                    if bonus_granted and referrer.telegram_id:
+                        try:
+                            user_bot.send_message(
+                                referrer.telegram_id,
+                                f"💰 Ваш приглашённый совершил первую оплату!\n"
+                                f"Ваша подписка продлена на "
+                                f"<b>{USER_BOT_REFERRAL_BONUS_DAYS} дней</b>.",
+                                parse_mode="HTML",
+                            )
+                        except Exception:
+                            pass
+
+        # Re-sync Xray
+        try:
+            from app import xray
+            xray.operations.update_user(db_user)
+        except Exception as exc:
+            logger.error("user_bot: xray.operations.update_user failed: %s", exc)
+
+        months  = {30: "1 месяц", 90: "3 месяца", 180: "6 месяцев"}.get(days, f"{days} дней")
+        reply   = (
+            f"✅ Оплата прошла успешно!\n\n"
+            f"Подписка продлена на <b>{months}</b>.\n\n"
+            + _account_text(db_user)
+        )
+
+    user_bot.send_message(
+        message.chat.id,
+        reply,
+        parse_mode="HTML",
+        reply_markup=UserBotKeyboard.main_menu(),
+    )

--- a/app/telegram/user_bot_instance.py
+++ b/app/telegram/user_bot_instance.py
@@ -1,0 +1,15 @@
+"""
+Singleton TeleBot instance for the user-facing bot.
+
+Imported by both the handler module and the telegram __init__ bootstrap,
+keeping them decoupled and avoiding circular imports.
+"""
+from config import TELEGRAM_PROXY_URL, TELEGRAM_USER_BOT_TOKEN
+from telebot import TeleBot, apihelper
+
+user_bot: TeleBot | None = None
+
+if TELEGRAM_USER_BOT_TOKEN:
+    if TELEGRAM_PROXY_URL:
+        apihelper.proxy = {"http": TELEGRAM_PROXY_URL, "https": TELEGRAM_PROXY_URL}
+    user_bot = TeleBot(TELEGRAM_USER_BOT_TOKEN)

--- a/app/telegram/utils/user_bot_keyboards.py
+++ b/app/telegram/utils/user_bot_keyboards.py
@@ -1,0 +1,77 @@
+"""
+Inline keyboards for the user-facing Telegram bot.
+All keyboard factory methods are static and return InlineKeyboardMarkup.
+"""
+from telebot.types import InlineKeyboardButton, InlineKeyboardMarkup
+
+from config import USER_BOT_STARS_1M, USER_BOT_STARS_3M, USER_BOT_STARS_6M
+
+
+class UserBotKeyboard:
+
+    @staticmethod
+    def main_menu() -> InlineKeyboardMarkup:
+        kb = InlineKeyboardMarkup(row_width=2)
+        kb.add(
+            InlineKeyboardButton("👤 Личный кабинет", callback_data="ub:cabinet"),
+            InlineKeyboardButton("📱 Мой конфиг", callback_data="ub:config"),
+        )
+        kb.add(
+            InlineKeyboardButton("💎 Продлить", callback_data="ub:buy"),
+            InlineKeyboardButton("👥 Реферальная программа", callback_data="ub:referral"),
+        )
+        return kb
+
+    @staticmethod
+    def back_to_menu() -> InlineKeyboardMarkup:
+        kb = InlineKeyboardMarkup()
+        kb.add(InlineKeyboardButton("🔙 Главное меню", callback_data="ub:menu"))
+        return kb
+
+    @staticmethod
+    def config_menu() -> InlineKeyboardMarkup:
+        kb = InlineKeyboardMarkup(row_width=2)
+        kb.add(
+            InlineKeyboardButton("🔗 Ссылка подписки", callback_data="ub:sub_url"),
+            InlineKeyboardButton("📷 QR-код", callback_data="ub:qr"),
+        )
+        kb.add(InlineKeyboardButton("🔙 Назад", callback_data="ub:menu"))
+        return kb
+
+    @staticmethod
+    def buy_menu() -> InlineKeyboardMarkup:
+        kb = InlineKeyboardMarkup(row_width=1)
+        kb.add(
+            InlineKeyboardButton(
+                f"1 месяц — {USER_BOT_STARS_1M} ⭐",
+                callback_data="ub:pay:30",
+            ),
+            InlineKeyboardButton(
+                f"3 месяца — {USER_BOT_STARS_3M} ⭐  (экономия ~7%)",
+                callback_data="ub:pay:90",
+            ),
+            InlineKeyboardButton(
+                f"6 месяцев — {USER_BOT_STARS_6M} ⭐  (экономия ~13%)",
+                callback_data="ub:pay:180",
+            ),
+        )
+        kb.add(InlineKeyboardButton("🔙 Назад", callback_data="ub:menu"))
+        return kb
+
+    @staticmethod
+    def pay_confirm(days: int, stars: int) -> InlineKeyboardMarkup:
+        kb = InlineKeyboardMarkup(row_width=2)
+        kb.add(
+            InlineKeyboardButton(
+                f"✅ Оплатить {stars} ⭐",
+                callback_data=f"ub:pay_confirm:{days}:{stars}",
+            ),
+            InlineKeyboardButton("❌ Отмена", callback_data="ub:buy"),
+        )
+        return kb
+
+    @staticmethod
+    def referral_menu() -> InlineKeyboardMarkup:
+        kb = InlineKeyboardMarkup()
+        kb.add(InlineKeyboardButton("🔙 Главное меню", callback_data="ub:menu"))
+        return kb

--- a/config.py
+++ b/config.py
@@ -45,6 +45,26 @@ TELEGRAM_PROXY_URL = config("TELEGRAM_PROXY_URL", default="")
 TELEGRAM_LOGGER_CHANNEL_ID = config("TELEGRAM_LOGGER_CHANNEL_ID", cast=int, default=0)
 TELEGRAM_DEFAULT_VLESS_FLOW = config("TELEGRAM_DEFAULT_VLESS_FLOW", default="")
 
+# ── User-facing bot ──────────────────────────────────────────────────────────
+TELEGRAM_USER_BOT_TOKEN = config("TELEGRAM_USER_BOT_TOKEN", default="")
+
+# Trial account settings
+USER_BOT_TRIAL_DAYS = config("USER_BOT_TRIAL_DAYS", cast=int, default=3)
+USER_BOT_TRIAL_GB = config("USER_BOT_TRIAL_GB", cast=int, default=3)
+
+# Telegram Stars prices (1 XTR ≈ 0.013 USD on Telegram)
+USER_BOT_STARS_1M = config("USER_BOT_STARS_1M", cast=int, default=100)   # 1 month
+USER_BOT_STARS_3M = config("USER_BOT_STARS_3M", cast=int, default=280)   # 3 months
+USER_BOT_STARS_6M = config("USER_BOT_STARS_6M", cast=int, default=520)   # 6 months
+
+# Referral protection
+# Days credited to the referrer per successful referral
+USER_BOT_REFERRAL_BONUS_DAYS = config("USER_BOT_REFERRAL_BONUS_DAYS", cast=int, default=7)
+# Hard cap on total referral-bonus days a single user can accumulate (0 = unlimited)
+USER_BOT_REFERRAL_MAX_BONUS_DAYS = config("USER_BOT_REFERRAL_MAX_BONUS_DAYS", cast=int, default=90)
+# If True, bonus is granted only AFTER the referred user makes their first Stars payment
+USER_BOT_REFERRAL_REQUIRE_PAYMENT = config("USER_BOT_REFERRAL_REQUIRE_PAYMENT", cast=bool, default=False)
+
 JWT_ACCESS_TOKEN_EXPIRE_MINUTES = config("JWT_ACCESS_TOKEN_EXPIRE_MINUTES", cast=int, default=1440)
 
 CUSTOM_TEMPLATES_DIRECTORY = config("CUSTOM_TEMPLATES_DIRECTORY", default=None)


### PR DESCRIPTION
New separate TeleBot instance (TELEGRAM_USER_BOT_TOKEN) running in its own daemon thread alongside the existing admin bot without touching it.

Features:
- /start: auto-creates trial account (configurable days/GB), supports referral deeplinks (ref_CODE)
- Personal cabinet: live status, traffic used/remaining, expiry date
- Config section: subscription URL + QR code generation in-memory
- Telegram Stars payments (1/3/6 months) with invoice flow and automatic Xray sync on successful payment
- Referral system: configurable bonus days, hard cap on total bonus, optional require-payment mode to prevent farming

DB changes:
- Alembic migration a1b2c3d4e5f6 adds telegram_id, referral_code, referred_by_id columns to the users table
- New CRUD helpers: get_user_by_telegram_id, get_user_by_referral_code, link_user_telegram_id, set_user_referral_code, record_referral, extend_user_expire, count_user_referrals

Bug fixes in bot code:
- DetachedInstanceError: _account_text() now called inside session
- IntegrityError on race condition handled with rollback + retry
- Double DB queries in cb_router collapsed into single session
- user_bot.get_me() result cached at module level
- Removed unused imports

Made-with: Cursor