### PR TITLE
NPVPN: add device limit for v2ray clients

### DIFF
--- a/app/dashboard/build/statics/locales/en.json
+++ b/app/dashboard/build/statics/locales/en.json
@@ -142,6 +142,7 @@
   "userDialog.absolute": "Absolute",
   "userDialog.custom": "Custom",
   "userDialog.dataLimit": "Data Limit",
+  "userDialog.deviceLimit": "Device Limit",
   "userDialog.days": "Days",
   "userDialog.editUser": "Edit user",
   "userDialog.editUserTitle": "Edit user",

--- a/app/dashboard/build/statics/locales/fa.json
+++ b/app/dashboard/build/statics/locales/fa.json
@@ -148,6 +148,7 @@
   "userDialog.absolute": "مطلق",
   "userDialog.custom": "انتخابی",
   "userDialog.dataLimit": "حد مصرف داده",
+  "userDialog.deviceLimit": "حداکثر دستگاه",
   "userDialog.days": "روزها",
   "userDialog.editUser": "ویرایش کاربر",
   "userDialog.editUserTitle": "ویرایش کاربر",

--- a/app/dashboard/build/statics/locales/ru.json
+++ b/app/dashboard/build/statics/locales/ru.json
@@ -142,6 +142,7 @@
   "userDialog.absolute": "Абсолютно",
   "userDialog.custom": "Пользовательский",
   "userDialog.dataLimit": "Лимит трафика",
+  "userDialog.deviceLimit": "Лимит устройств",
   "userDialog.days": "Дни",
   "userDialog.editUser": "Редактировать",
   "userDialog.editUserTitle": "Редактировать пользователя",

--- a/app/dashboard/build/statics/locales/zh.json
+++ b/app/dashboard/build/statics/locales/zh.json
@@ -142,6 +142,7 @@
   "userDialog.absolute": "选择范围",
   "userDialog.custom": "自定义",
   "userDialog.dataLimit": "流量限制",
+  "userDialog.deviceLimit": "设备数量上限",
   "userDialog.days": "天",
   "userDialog.editUser": "修改",
   "userDialog.editUserTitle": "用户编辑",

--- a/app/dashboard/public/statics/locales/en.json
+++ b/app/dashboard/public/statics/locales/en.json
@@ -143,6 +143,7 @@
   "userDialog.absolute": "Absolute",
   "userDialog.custom": "Custom",
   "userDialog.dataLimit": "Data Limit",
+  "userDialog.deviceLimit": "Device Limit",
   "userDialog.days": "Days",
   "userDialog.editUser": "Edit user",
   "userDialog.editUserTitle": "Edit user",

--- a/app/dashboard/public/statics/locales/fa.json
+++ b/app/dashboard/public/statics/locales/fa.json
@@ -149,6 +149,7 @@
   "userDialog.absolute": "مطلق",
   "userDialog.custom": "انتخابی",
   "userDialog.dataLimit": "حد مصرف داده",
+  "userDialog.deviceLimit": "حداکثر دستگاه",
   "userDialog.days": "روزها",
   "userDialog.editUser": "ویرایش کاربر",
   "userDialog.editUserTitle": "ویرایش کاربر",

--- a/app/dashboard/public/statics/locales/ru.json
+++ b/app/dashboard/public/statics/locales/ru.json
@@ -143,6 +143,7 @@
   "userDialog.absolute": "Абсолютно",
   "userDialog.custom": "Пользовательский",
   "userDialog.dataLimit": "Лимит трафика",
+  "userDialog.deviceLimit": "Лимит устройств",
   "userDialog.days": "Дни",
   "userDialog.editUser": "Редактировать",
   "userDialog.editUserTitle": "Редактировать пользователя",

--- a/app/dashboard/public/statics/locales/zh.json
+++ b/app/dashboard/public/statics/locales/zh.json
@@ -143,6 +143,7 @@
   "userDialog.absolute": "选择范围",
   "userDialog.custom": "自定义",
   "userDialog.dataLimit": "流量限制",
+  "userDialog.deviceLimit": "设备数量上限",
   "userDialog.days": "天",
   "userDialog.editUser": "修改",
   "userDialog.editUserTitle": "用户编辑",

--- a/app/dashboard/src/components/UserDialog.tsx
+++ b/app/dashboard/src/components/UserDialog.tsx
@@ -110,6 +110,7 @@ const getDefaultValues = (): FormType => {
   return {
     selected_proxies: Object.keys(defaultInbounds) as ProxyKeys,
     data_limit: null,
+    device_limit: null,
     expire: null,
     username: "",
     data_limit_reset_strategy: "no_reset",
@@ -171,6 +172,15 @@ const baseSchema = {
     .nullable()
     .transform((str) => {
       if (str) return Number((parseFloat(String(str)) * 1073741824).toFixed(5));
+      return 0;
+    }),
+  device_limit: z
+    .string()
+    .min(0)
+    .or(z.number())
+    .nullable()
+    .transform((str) => {
+      if (str) return Number(String(str));
       return 0;
     }),
   expire: z.number().nullable(),
@@ -532,6 +542,28 @@ export const UserDialog: FC<UserDialogProps> = () => {
                                 disabled={disabled}
                                 error={
                                   form.formState.errors.data_limit?.message
+                                }
+                                value={field.value ? String(field.value) : ""}
+                              />
+                            );
+                          }}
+                        />
+                      </FormControl>
+                      <FormControl mb={"10px"}>
+                        <FormLabel>{t("userDialog.deviceLimit")}</FormLabel>
+                        <Controller
+                          control={form.control}
+                          name="device_limit"
+                          render={({ field }) => {
+                            return (
+                              <Input
+                                type="number"
+                                size="sm"
+                                borderRadius="6px"
+                                onChange={field.onChange}
+                                disabled={disabled}
+                                error={
+                                  form.formState.errors.device_limit?.message
                                 }
                                 value={field.value ? String(field.value) : ""}
                               />

--- a/app/dashboard/src/types/User.ts
+++ b/app/dashboard/src/types/User.ts
@@ -39,6 +39,7 @@ export type User = {
   proxies: ProxyType;
   expire: number | null;
   data_limit: number | null;
+  device_limit: number | null;
   data_limit_reset_strategy: DataLimitResetStrategy;
   on_hold_expire_duration: number | null;
   lifetime_used_traffic: number;
@@ -58,6 +59,7 @@ export type UserCreate = Pick<
   | "proxies"
   | "expire"
   | "data_limit"
+  | "device_limit"
   | "data_limit_reset_strategy"
   | "on_hold_expire_duration"
   | "username"

--- a/app/db/crud.py
+++ b/app/db/crud.py
@@ -7,6 +7,7 @@ from enum import Enum
 from typing import Dict, List, Optional, Tuple, Union
 
 from sqlalchemy import and_, delete, func, or_
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Query, Session, joinedload
 from sqlalchemy.sql.functions import coalesce
 
@@ -26,6 +27,7 @@ from app.db.models import (
     ProxyTypes,
     System,
     User,
+    UserDevice,
     UserTemplate,
     UserUsageResetLogs,
 )
@@ -36,6 +38,8 @@ from app.models.user import (
     ReminderType,
     UserCreate,
     UserDataLimitResetStrategy,
+    UserDeviceCreate,
+    UserDeviceUpdate,
     UserModify,
     UserResponse,
     UserStatus,
@@ -383,6 +387,7 @@ def create_user(db: Session, user: UserCreate, admin: Admin = None) -> User:
         proxies=proxies,
         status=user.status,
         data_limit=(user.data_limit or None),
+        device_limit=(user.device_limit or None),
         expire=(user.expire or None),
         admin=admin,
         data_limit_reset_strategy=user.data_limit_reset_strategy,
@@ -488,6 +493,9 @@ def update_user(db: Session, dbuser: User, modify: UserModify) -> User:
             else:
                 dbuser.status = UserStatus.limited
 
+    if modify.device_limit is not None:
+        dbuser.device_limit = (modify.device_limit or None)
+
     if modify.expire is not None:
         dbuser.expire = (modify.expire or None)
         if dbuser.status in (UserStatus.active, UserStatus.expired):
@@ -530,6 +538,118 @@ def update_user(db: Session, dbuser: User, modify: UserModify) -> User:
     db.commit()
     db.refresh(dbuser)
     return dbuser
+
+
+def get_user_devices(db: Session, dbuser: User) -> List[UserDevice]:
+    return (
+        db.query(UserDevice)
+        .filter(UserDevice.user_id == dbuser.id)
+        .order_by(UserDevice.last_seen.desc())
+        .all()
+    )
+
+
+def get_user_device(db: Session, dbuser: User, device_id: int) -> Optional[UserDevice]:
+    return (
+        db.query(UserDevice)
+        .filter(UserDevice.user_id == dbuser.id, UserDevice.id == device_id)
+        .first()
+    )
+
+
+def get_user_device_by_hwid(db: Session, dbuser: User, hwid: str) -> Optional[UserDevice]:
+    return (
+        db.query(UserDevice)
+        .filter(UserDevice.user_id == dbuser.id, UserDevice.hwid == hwid)
+        .first()
+    )
+
+
+def count_user_devices(db: Session, dbuser: User) -> int:
+    return db.query(func.count(UserDevice.id)).filter(UserDevice.user_id == dbuser.id).scalar() or 0
+
+
+def create_user_device(db: Session, dbuser: User, device: UserDeviceCreate) -> UserDevice:
+    dbdevice = UserDevice(
+        user_id=dbuser.id,
+        hwid=device.hwid,
+        device_os=device.device_os,
+        ver_os=device.ver_os,
+        device_model=device.device_model,
+        user_agent=device.user_agent,
+    )
+    db.add(dbdevice)
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        raise
+    db.refresh(dbdevice)
+    return dbdevice
+
+
+def update_user_device(db: Session, dbdevice: UserDevice, device: UserDeviceUpdate) -> UserDevice:
+    if device.hwid is not None:
+        dbdevice.hwid = device.hwid
+    if device.device_os is not None:
+        dbdevice.device_os = device.device_os
+    if device.ver_os is not None:
+        dbdevice.ver_os = device.ver_os
+    if device.device_model is not None:
+        dbdevice.device_model = device.device_model
+    if device.user_agent is not None:
+        dbdevice.user_agent = device.user_agent
+    db.commit()
+    db.refresh(dbdevice)
+    return dbdevice
+
+
+def delete_user_device(db: Session, dbdevice: UserDevice) -> None:
+    db.delete(dbdevice)
+    db.commit()
+
+
+def register_user_device(
+    db: Session,
+    dbuser: User,
+    hwid: Optional[str],
+    device_os: Optional[str],
+    ver_os: Optional[str],
+    device_model: Optional[str],
+    user_agent: Optional[str],
+) -> bool:
+    effective_hwid = hwid or "unknown"
+
+    dbdevice = get_user_device_by_hwid(db, dbuser, effective_hwid)
+    if dbdevice:
+        dbdevice.device_os = device_os or dbdevice.device_os
+        dbdevice.ver_os = ver_os or dbdevice.ver_os
+        dbdevice.device_model = device_model or dbdevice.device_model
+        dbdevice.user_agent = user_agent or dbdevice.user_agent
+        dbdevice.last_seen = datetime.utcnow()
+        db.commit()
+        return True
+
+    if dbuser.device_limit:
+        current = count_user_devices(db, dbuser)
+        if current >= dbuser.device_limit:
+            return False
+
+    dbdevice = UserDevice(
+        user_id=dbuser.id,
+        hwid=effective_hwid,
+        device_os=device_os,
+        ver_os=ver_os,
+        device_model=device_model,
+        user_agent=user_agent,
+    )
+    db.add(dbdevice)
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        return True
+    return True
 
 
 def reset_user_data_usage(db: Session, dbuser: User) -> User:

--- a/app/db/migrations/versions/4b3c9d1a2f6e_user_devices_and_device_limit.py
+++ b/app/db/migrations/versions/4b3c9d1a2f6e_user_devices_and_device_limit.py
@@ -1,0 +1,41 @@
+"""add device_limit and user_devices
+
+Revision ID: 4b3c9d1a2f6e
+Revises: 2b231de97dc3
+Create Date: 2026-03-10 00:00:00.000000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '4b3c9d1a2f6e'
+down_revision = '2b231de97dc3'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table('users') as batch_op:
+        batch_op.add_column(sa.Column('device_limit', sa.Integer(), nullable=True))
+
+    op.create_table(
+        'user_devices',
+        sa.Column('id', sa.Integer(), primary_key=True),
+        sa.Column('user_id', sa.Integer(), sa.ForeignKey('users.id'), nullable=False),
+        sa.Column('hwid', sa.String(length=128), nullable=False),
+        sa.Column('device_os', sa.String(length=64), nullable=True),
+        sa.Column('ver_os', sa.String(length=64), nullable=True),
+        sa.Column('device_model', sa.String(length=128), nullable=True),
+        sa.Column('user_agent', sa.String(length=512), nullable=True),
+        sa.Column('first_seen', sa.DateTime(), nullable=False, server_default=sa.text('CURRENT_TIMESTAMP')),
+        sa.Column('last_seen', sa.DateTime(), nullable=False, server_default=sa.text('CURRENT_TIMESTAMP')),
+        sa.UniqueConstraint('user_id', 'hwid', name='uq_user_devices_user_id_hwid'),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('user_devices')
+    with op.batch_alter_table('users') as batch_op:
+        batch_op.drop_column('device_limit')
+

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -62,6 +62,9 @@ class User(BaseModel):
     data_limit: Optional[int] = Field(
         ge=0, default=None, description="data_limit can be 0 or greater"
     )
+    device_limit: Optional[int] = Field(
+        ge=0, default=None, description="device_limit can be 0 or greater"
+    )
     data_limit_reset_strategy: UserDataLimitResetStrategy = (
         UserDataLimitResetStrategy.no_reset
     )
@@ -86,6 +89,16 @@ class User(BaseModel):
         if isinstance(v, int):  # Allow integers directly
             return v
         raise ValueError("data_limit must be an integer or a float, not a string")  # Reject strings
+
+    @field_validator('device_limit', mode='before')
+    def cast_device_limit_to_int(cls, v):
+        if v is None:  # Allow None values
+            return v
+        if isinstance(v, float):  # Allow float to int conversion
+            return int(v)
+        if isinstance(v, int):  # Allow integers directly
+            return v
+        raise ValueError("device_limit must be an integer or a float, not a string")  # Reject strings
 
     @field_validator("proxies", mode="before")
     def validate_proxies(cls, v, values, **kwargs):
@@ -364,3 +377,34 @@ class UserUsagesResponse(BaseModel):
 
 class UsersUsagesResponse(BaseModel):
     usages: List[UserUsageResponse]
+
+
+class UserDeviceBase(BaseModel):
+    hwid: str
+    device_os: Optional[str] = None
+    ver_os: Optional[str] = None
+    device_model: Optional[str] = None
+    user_agent: Optional[str] = None
+
+
+class UserDeviceCreate(UserDeviceBase):
+    pass
+
+
+class UserDeviceUpdate(BaseModel):
+    hwid: Optional[str] = None
+    device_os: Optional[str] = None
+    ver_os: Optional[str] = None
+    device_model: Optional[str] = None
+    user_agent: Optional[str] = None
+
+
+class UserDeviceResponse(UserDeviceBase):
+    id: int
+    first_seen: datetime
+    last_seen: datetime
+    model_config = ConfigDict(from_attributes=True)
+
+
+class UserDevicesResponse(BaseModel):
+    devices: List[UserDeviceResponse]

--- a/app/routers/subscription.py
+++ b/app/routers/subscription.py
@@ -1,5 +1,6 @@
 import re
 from distutils.version import LooseVersion
+from typing import Optional
 
 from fastapi import APIRouter, Depends, Header, Path, Request, Response
 from fastapi.responses import HTMLResponse
@@ -51,7 +52,11 @@ def user_subscription(
     request: Request,
     db: Session = Depends(get_db),
     dbuser: UserResponse = Depends(get_validated_sub),
-    user_agent: str = Header(default="")
+    user_agent: str = Header(default=""),
+    x_hwid: Optional[str] = Header(default=None),
+    x_device_os: Optional[str] = Header(default=None),
+    x_ver_os: Optional[str] = Header(default=None),
+    x_device_model: Optional[str] = Header(default=None),
 ):
     """Provides a subscription link based on the user agent (Clash, V2Ray, etc.)."""
     user: UserResponse = UserResponse.model_validate(dbuser)
@@ -64,6 +69,15 @@ def user_subscription(
                 {"user": user}
             )
         )
+
+    device_limited = False
+    if dbuser.device_limit:
+        registered = crud.register_user_device(
+            db, dbuser, x_hwid, x_device_os, x_ver_os, x_device_model, user_agent
+        )
+        device_limited = not registered
+        if device_limited:
+            user = user.model_copy(update={"proxies": {}, "inbounds": {}})
 
     crud.update_user_sub(db, dbuser, user_agent)
     response_headers = {
@@ -79,63 +93,63 @@ def user_subscription(
     }
 
     if re.match(r'^([Cc]lash-verge|[Cc]lash[-\.]?[Mm]eta|[Ff][Ll][Cc]lash|[Mm]ihomo)', user_agent):
-        conf = generate_subscription(user=user, config_format="clash-meta", as_base64=False, reverse=False)
+        conf = generate_subscription(user=user, config_format="clash-meta", as_base64=False, reverse=False, device_limited=device_limited)
         return Response(content=conf, media_type="text/yaml", headers=response_headers)
 
     elif re.match(r'^([Cc]lash|[Ss]tash)', user_agent):
-        conf = generate_subscription(user=user, config_format="clash", as_base64=False, reverse=False)
+        conf = generate_subscription(user=user, config_format="clash", as_base64=False, reverse=False, device_limited=device_limited)
         return Response(content=conf, media_type="text/yaml", headers=response_headers)
 
     elif re.match(r'^(SFA|SFI|SFM|SFT|[Kk]aring|[Hh]iddify[Nn]ext)', user_agent):
-        conf = generate_subscription(user=user, config_format="sing-box", as_base64=False, reverse=False)
+        conf = generate_subscription(user=user, config_format="sing-box", as_base64=False, reverse=False, device_limited=device_limited)
         return Response(content=conf, media_type="application/json", headers=response_headers)
 
     elif re.match(r'^(SS|SSR|SSD|SSS|Outline|Shadowsocks|SSconf)', user_agent):
-        conf = generate_subscription(user=user, config_format="outline", as_base64=False, reverse=False)
+        conf = generate_subscription(user=user, config_format="outline", as_base64=False, reverse=False, device_limited=device_limited)
         return Response(content=conf, media_type="application/json", headers=response_headers)
 
     elif (USE_CUSTOM_JSON_DEFAULT or USE_CUSTOM_JSON_FOR_V2RAYN) and re.match(r'^v2rayN/(\d+\.\d+)', user_agent):
         version_str = re.match(r'^v2rayN/(\d+\.\d+)', user_agent).group(1)
         if LooseVersion(version_str) >= LooseVersion("6.40"):
-            conf = generate_subscription(user=user, config_format="v2ray-json", as_base64=False, reverse=False)
+            conf = generate_subscription(user=user, config_format="v2ray-json", as_base64=False, reverse=False, device_limited=device_limited)
             return Response(content=conf, media_type="application/json", headers=response_headers)
         else:
-            conf = generate_subscription(user=user, config_format="v2ray", as_base64=True, reverse=False)
+            conf = generate_subscription(user=user, config_format="v2ray", as_base64=True, reverse=False, device_limited=device_limited)
             return Response(content=conf, media_type="text/plain", headers=response_headers)
 
     elif (USE_CUSTOM_JSON_DEFAULT or USE_CUSTOM_JSON_FOR_V2RAYNG) and re.match(r'^v2rayNG/(\d+\.\d+\.\d+)', user_agent):
         version_str = re.match(r'^v2rayNG/(\d+\.\d+\.\d+)', user_agent).group(1)
         if LooseVersion(version_str) >= LooseVersion("1.8.29"):
-            conf = generate_subscription(user=user, config_format="v2ray-json", as_base64=False, reverse=False)
+            conf = generate_subscription(user=user, config_format="v2ray-json", as_base64=False, reverse=False, device_limited=device_limited)
             return Response(content=conf, media_type="application/json", headers=response_headers)
         elif LooseVersion(version_str) >= LooseVersion("1.8.18"):
-            conf = generate_subscription(user=user, config_format="v2ray-json", as_base64=False, reverse=True)
+            conf = generate_subscription(user=user, config_format="v2ray-json", as_base64=False, reverse=True, device_limited=device_limited)
             return Response(content=conf, media_type="application/json", headers=response_headers)
         else:
-            conf = generate_subscription(user=user, config_format="v2ray", as_base64=True, reverse=False)
+            conf = generate_subscription(user=user, config_format="v2ray", as_base64=True, reverse=False, device_limited=device_limited)
             return Response(content=conf, media_type="text/plain", headers=response_headers)
 
     elif re.match(r'^[Ss]treisand', user_agent):
         if USE_CUSTOM_JSON_DEFAULT or USE_CUSTOM_JSON_FOR_STREISAND:
-            conf = generate_subscription(user=user, config_format="v2ray-json", as_base64=False, reverse=False)
+            conf = generate_subscription(user=user, config_format="v2ray-json", as_base64=False, reverse=False, device_limited=device_limited)
             return Response(content=conf, media_type="application/json", headers=response_headers)
         else:
-            conf = generate_subscription(user=user, config_format="v2ray", as_base64=True, reverse=False)
+            conf = generate_subscription(user=user, config_format="v2ray", as_base64=True, reverse=False, device_limited=device_limited)
             return Response(content=conf, media_type="text/plain", headers=response_headers)
 
     elif (USE_CUSTOM_JSON_DEFAULT or USE_CUSTOM_JSON_FOR_HAPP) and re.match(r'^Happ/(\d+\.\d+\.\d+)', user_agent):
         version_str = re.match(r'^Happ/(\d+\.\d+\.\d+)', user_agent).group(1)
         if LooseVersion(version_str) >= LooseVersion("1.63.1"):
-            conf = generate_subscription(user=user, config_format="v2ray-json", as_base64=False, reverse=False)
+            conf = generate_subscription(user=user, config_format="v2ray-json", as_base64=False, reverse=False, device_limited=device_limited)
             return Response(content=conf, media_type="application/json", headers=response_headers)
         else:
-            conf = generate_subscription(user=user, config_format="v2ray", as_base64=True, reverse=False)
+            conf = generate_subscription(user=user, config_format="v2ray", as_base64=True, reverse=False, device_limited=device_limited)
             return Response(content=conf, media_type="text/plain", headers=response_headers)
 
 
 
     else:
-        conf = generate_subscription(user=user, config_format="v2ray", as_base64=True, reverse=False)
+        conf = generate_subscription(user=user, config_format="v2ray", as_base64=True, reverse=False, device_limited=device_limited)
         return Response(content=conf, media_type="text/plain", headers=response_headers)
 
 

--- a/app/routers/user.py
+++ b/app/routers/user.py
@@ -10,6 +10,10 @@ from app.dependencies import get_expired_users_list, get_validated_user, validat
 from app.models.admin import Admin
 from app.models.user import (
     UserCreate,
+    UserDeviceCreate,
+    UserDeviceResponse,
+    UserDeviceUpdate,
+    UserDevicesResponse,
     UserModify,
     UserResponse,
     UsersResponse,
@@ -73,6 +77,78 @@ def add_user(
 def get_user(dbuser: UserResponse = Depends(get_validated_user)):
     """Get user information"""
     return dbuser
+
+
+@router.get(
+    "/user/{username}/devices",
+    response_model=UserDevicesResponse,
+    responses={403: responses._403, 404: responses._404},
+)
+def list_user_devices(
+    dbuser: UserResponse = Depends(get_validated_user),
+    db: Session = Depends(get_db),
+):
+    devices = crud.get_user_devices(db, dbuser)
+    return {"devices": devices}
+
+
+@router.post(
+    "/user/{username}/devices",
+    response_model=UserDeviceResponse,
+    responses={400: responses._400, 403: responses._403, 404: responses._404, 409: responses._409},
+)
+def add_user_device(
+    device: UserDeviceCreate,
+    dbuser: UserResponse = Depends(get_validated_user),
+    db: Session = Depends(get_db),
+):
+    if dbuser.device_limit and crud.count_user_devices(db, dbuser) >= dbuser.device_limit:
+        raise HTTPException(status_code=403, detail="Device limit reached")
+    try:
+        dbdevice = crud.create_user_device(db, dbuser, device)
+    except IntegrityError:
+        raise HTTPException(status_code=409, detail="Device already exists")
+    return dbdevice
+
+
+@router.put(
+    "/user/{username}/devices/{device_id}",
+    response_model=UserDeviceResponse,
+    responses={400: responses._400, 403: responses._403, 404: responses._404, 409: responses._409},
+)
+def update_user_device(
+    device_id: int,
+    device: UserDeviceUpdate,
+    dbuser: UserResponse = Depends(get_validated_user),
+    db: Session = Depends(get_db),
+):
+    dbdevice = crud.get_user_device(db, dbuser, device_id)
+    if not dbdevice:
+        raise HTTPException(status_code=404, detail="Device not found")
+    if device.hwid:
+        existing = crud.get_user_device_by_hwid(db, dbuser, device.hwid)
+        if existing and existing.id != dbdevice.id:
+            raise HTTPException(status_code=409, detail="Device already exists")
+    try:
+        return crud.update_user_device(db, dbdevice, device)
+    except IntegrityError:
+        raise HTTPException(status_code=409, detail="Device already exists")
+
+
+@router.delete(
+    "/user/{username}/devices/{device_id}",
+    responses={403: responses._403, 404: responses._404},
+)
+def delete_user_device(
+    device_id: int,
+    dbuser: UserResponse = Depends(get_validated_user),
+    db: Session = Depends(get_db),
+):
+    dbdevice = crud.get_user_device(db, dbuser, device_id)
+    if not dbdevice:
+        raise HTTPException(status_code=404, detail="Device not found")
+    crud.delete_user_device(db, dbdevice)
+    return {"detail": "Device successfully deleted"}
 
 
 @router.put("/user/{username}", response_model=UserResponse, responses={400: responses._400, 403: responses._403, 404: responses._404})

--- a/app/subscription/share.py
+++ b/app/subscription/share.py
@@ -102,7 +102,10 @@ def generate_subscription(
         config_format: Literal["v2ray", "clash-meta", "clash", "sing-box", "outline", "v2ray-json"],
         as_base64: bool,
         reverse: bool,
+        device_limited: bool = False,
 ) -> str:
+    from config import SUB_DEVICE_LIMIT_SERVER_TEXT
+
     kwargs = {
         "proxies": user.proxies,
         "inbounds": user.inbounds,
@@ -110,7 +113,26 @@ def generate_subscription(
         "reverse": reverse,
     }
 
-    if config_format == "v2ray":
+    if config_format == "v2ray" and device_limited:
+        if not SUB_DEVICE_LIMIT_SERVER_TEXT:
+            config = ""
+        else:
+            zero_id = "00000000-0000-0000-0000-000000000000"
+            links = [
+                V2rayShareLink.vless(
+                    remark=remark,
+                    address="0.0.0.0",
+                    port=0,
+                    id=zero_id,
+                    net="ws",
+                    tls="none",
+                    path="",
+                    host="",
+                )
+                for remark in SUB_DEVICE_LIMIT_SERVER_TEXT
+            ]
+            config = "\n".join(links)
+    elif config_format == "v2ray":
         config = "\n".join(generate_v2ray_links(**kwargs))
     elif config_format == "clash-meta":
         config = generate_clash_subscription(**kwargs, is_meta=True)

--- a/config.py
+++ b/config.py
@@ -136,6 +136,19 @@ SUB_UPDATE_INTERVAL = config("SUB_UPDATE_INTERVAL", default="12")
 SUB_SUPPORT_URL = config("SUB_SUPPORT_URL", default="https://t.me/")
 SUB_PROFILE_TITLE = config("SUB_PROFILE_TITLE", default="Subscription")
 
+
+def _parse_server_text_list(v):
+    if v is None or v == "":
+        return []
+    return [s.strip() for s in str(v).split(",")]
+
+
+SUB_DEVICE_LIMIT_SERVER_TEXT = config(
+    "SUB_DEVICE_LIMIT_SERVER_TEXT",
+    default="Device limit reached",
+    cast=lambda v: _parse_server_text_list(v),
+)
+
 # discord webhook log
 DISCORD_WEBHOOK_URL = config("DISCORD_WEBHOOK_URL", default="")
 


### PR DESCRIPTION
Solution from NPVPN panel
## Summary

This PR adds optional per-user device limits: admins can cap how many distinct devices can use a subscription. When the limit is reached, new devices are rejected and the subscription endpoint returns an empty/placeholder config so clients show a clear "device limit reached" state instead of valid nodes.

## Changes

**Database.** New column `users.device_limit` (optional). New table `user_devices` — one row per device per user (by `user_id` + `hwid`), with optional metadata.

**Subscription flow.** Handler reads optional headers `X-HWID`, `X-Device-OS`, `X-Ver-OS`, `X-Device-Model` and registers/updates the device by HWID. Over limit → empty config (and for v2ray, configurable placeholder lines so the client can show a message).

**API.** User create/update support `device_limit`. New device endpoints (admin only): list, add, update, delete user devices. Adding over limit returns 403.

**Config.** `SUB_DEVICE_LIMIT_SERVER_TEXT` — comma-separated strings for placeholder v2ray nodes when limited. Optional.

**Dashboard.** Optional "Device limit" field in user create/edit dialog. Locales: EN, RU, FA, ZH.

**Backward compatibility.** `device_limit` defaults to null; existing users unchanged. New env var optional. 

Issues: #1383 #1760 #457 #1784 #754 