### PR TITLE
fix: add timeout to _connecting_nodes guard to prevent permanent stuck state

### DIFF
--- a/app/xray/operations.py
+++ b/app/xray/operations.py
@@ -1,3 +1,4 @@
+import time
 from functools import lru_cache
 from typing import TYPE_CHECKING
 
@@ -191,13 +192,27 @@ def _change_node_status(node_id: int, status: NodeStatus, message: str = None, v
 global _connecting_nodes
 _connecting_nodes = {}
 
+# Maximum time (in seconds) a node is allowed to stay in the
+# "connecting" state before the guard is considered stale.  If a
+# connect_node thread hangs longer than this, subsequent calls will
+# discard the stale guard and start a new connection attempt instead
+# of silently returning.
+CONNECTING_TIMEOUT = 120
+
 
 @threaded_function
 def connect_node(node_id, config=None):
     global _connecting_nodes
 
-    if _connecting_nodes.get(node_id):
+    started_at = _connecting_nodes.get(node_id)
+    if started_at and (time.monotonic() - started_at) < CONNECTING_TIMEOUT:
         return
+
+    if started_at:
+        logger.warning(
+            f"Connecting guard for node {node_id} expired after "
+            f"{time.monotonic() - started_at:.0f}s, retrying connection"
+        )
 
     with GetDB() as db:
         dbnode = crud.get_node_by_id(db, node_id)
@@ -212,7 +227,7 @@ def connect_node(node_id, config=None):
         node = xray.operations.add_node(dbnode)
 
     try:
-        _connecting_nodes[node_id] = True
+        _connecting_nodes[node_id] = time.monotonic()
 
         _change_node_status(node_id, NodeStatus.connecting)
         logger.info(f"Connecting to \"{dbnode.name}\" node")


### PR DESCRIPTION
## Summary

- Nodes can get permanently stuck in "connecting" status if a `connect_node` thread hangs (e.g. due to network timeout in `ssl.get_server_certificate()` or `node.start()`)
- The `_connecting_nodes` boolean guard blocks **all** subsequent reconnection attempts — health checks, manual reconnect from panel, and `/api/core/restart` — silently returning without doing anything
- The only recovery is restarting the entire Marzban container

This fix replaces the boolean guard with a `time.monotonic()` timestamp. If a connection attempt exceeds 120 seconds, the guard is considered stale and a new attempt is allowed. A warning is logged when an expired guard is detected.

## Root cause

`_connecting_nodes[node_id] = True` is set at the start of `connect_node()` and cleared in `finally`. If the thread hangs indefinitely (no timeout on `ssl.get_server_certificate()`, RPyC calls, etc.), the flag is never cleared. The guard check `if _connecting_nodes.get(node_id): return` then rejects every future call.

## Changes

- `_connecting_nodes` now stores `time.monotonic()` timestamps instead of `True`
- Guard check compares elapsed time against `CONNECTING_TIMEOUT` (120s)
- Logs a warning when a stale guard is expired, for visibility

## Related issues

- #1560 — nodes stuck in "connecting", only reboot helps
- #1313 — node connection problem after address change, needs multiple reboots
- #1609 — frequent timeout errors causing node disconnections

## Test plan

- [ ] Verify normal node connection/disconnection cycle is unaffected
- [ ] Simulate a hanging connection (e.g. firewall drop on node port) and verify the node recovers after 120s without container restart
- [ ] Verify the warning log appears when a stale guard is expired