### PR TITLE
fix: use compact JSON for xhttp extra param to avoid + signs in subscription URLs

### DIFF
--- a/app/subscription/v2ray.py
+++ b/app/subscription/v2ray.py
@@ -326,7 +326,7 @@ class V2rayShareLink(str):
                 extra["keepAlivePeriod"] = keepAlivePeriod
             if xmux:
                 extra["xmux"] = xmux
-            payload["extra"] = json.dumps(extra)
+            payload["extra"] = json.dumps(extra, separators=(',', ':'))
 
         elif net == 'kcp':
             payload['seed'] = path
@@ -430,7 +430,7 @@ class V2rayShareLink(str):
                 extra["keepAlivePeriod"] = keepAlivePeriod
             if xmux:
                 extra["xmux"] = xmux
-            payload["extra"] = json.dumps(extra)
+            payload["extra"] = json.dumps(extra, separators=(',', ':'))
 
         elif net == 'quic':
             payload['key'] = path


### PR DESCRIPTION
## Problem

When generating VLESS/VMESS subscription links for `xhttp` (and `splithttp`) inbounds, the `extra` parameter is encoded with `+` signs instead of proper URL encoding.

**Root cause:**

`json.dumps(extra)` uses spaces after separators by default (e.g. `{"key": value, "key2": value2}`). These spaces are then URL-encoded by `urllib.parse.urlencode()` which uses `quote_plus()` — converting spaces to `+` rather than `%20`.

The result in the subscription URL looks like:
```
extra=%7B%22scMaxEachPostBytes%22%3A+1000000%2C+%22scMaxConcurrentPosts%22%3A+100%2C+...%7D
```

Clients like **v2rayN** attempt to parse this as JSON after URL-decoding, but `+` is not decoded as a space in JSON context, producing parse errors or incorrect values being shown.

## Fix

Use `separators=(',', ':')` in `json.dumps()` to produce compact JSON with no spaces:

```python
# Before
payload["extra"] = json.dumps(extra)

# After  
payload["extra"] = json.dumps(extra, separators=(',', ':'))
```

This produces `{"scMaxEachPostBytes":1000000,...}` — no spaces, no `+` signs in the URL.

## Affected locations

Both occurrences in `app/subscription/v2ray.py`:
- Line 329 (VLESS link generation)
- Line 433 (VMESS link generation)

## Testing

Before fix — extra param in subscription URL:
```
extra=%7B%22scMaxEachPostBytes%22%3A+1000000%2C+%22scMaxConcurrentPosts%22%3A+100%7D
```

After fix — extra param in subscription URL:
```
extra=%7B%22scMaxEachPostBytes%22%3A1000000%2C%22scMaxConcurrentPosts%22%3A100%7D
```