### PR TITLE
fix(subscription): write reality sid to host_inbound, not the shared inbound dict

### DIFF
--- a/app/subscription/share.py
+++ b/app/subscription/share.py
@@ -287,7 +287,7 @@ def process_inbounds_and_tags(
                     sni = random.choice(sni_list).replace("*", salt)
 
                 if sids := inbound.get("sids"):
-                    inbound["sid"] = random.choice(sids)
+                    host_inbound["sid"] = random.choice(sids)
 
                 req_host = ""
                 req_host_list = host["host"] or inbound["host"]


### PR DESCRIPTION
closes #1986

`host_inbound = inbound.copy()` is taken before the host loop. the random shortId pick was writing to the original `inbound` (the shared `xray.config.inbounds_by_tag[tag]`), so `host_inbound["sid"]` stayed unset and the URL came out with empty `&sid=`. moving the assignment to `host_inbound` fixes it and stops mutating shared config along the way.

```diff
                if sids := inbound.get("sids"):
-                   inbound["sid"] = random.choice(sids)
+                   host_inbound["sid"] = random.choice(sids)
```

repro: restart marzban, copy any reality user's config — first copy emits empty `sid=`. refresh the page and copy again — `sid=` is now populated.

non-reality inbounds don't have `sids` so the branch is skipped — no behavior change there.