### PR TITLE
fix: critical correctness bugs and thread-safety hardening

### DIFF
--- a/app/db/crud.py
+++ b/app/db/crud.py
@@ -589,7 +589,7 @@ def reset_user_by_next(db: Session, dbuser: User) -> User:
     dbuser.status = UserStatus.active.value
 
     dbuser.data_limit = dbuser.next_plan.data_limit + \
-        (0 if dbuser.next_plan.add_remaining_traffic else dbuser.data_limit - dbuser.used_traffic)
+        (dbuser.data_limit - dbuser.used_traffic if dbuser.next_plan.add_remaining_traffic else 0)
     dbuser.expire = int((timedelta(seconds=dbuser.next_plan.expire) + datetime.utcnow()).timestamp())
 
     dbuser.used_traffic = 0
@@ -788,7 +788,7 @@ def get_all_users_usages(
             used_traffic=0
         )
 
-    admin_users = set(user.id for user in get_users(db=db, admins=admin))
+    admin_users = set(user.id for user in get_users(db=db, admin=admin))
 
     cond = and_(
         NodeUserUsage.created_at >= start,
@@ -951,7 +951,7 @@ def update_admin(db: Session, dbadmin: Admin, modified_admin: AdminModify) -> Ad
     Returns:
         Admin: The updated admin object.
     """
-    if modified_admin.is_sudo:
+    if modified_admin.is_sudo is not None:
         dbadmin.is_sudo = modified_admin.is_sudo
     if modified_admin.password is not None and dbadmin.hashed_password != modified_admin.hashed_password:
         dbadmin.hashed_password = modified_admin.hashed_password

--- a/app/jobs/record_usages.py
+++ b/app/jobs/record_usages.py
@@ -110,12 +110,19 @@ def record_node_stats(params: dict, node_id: Union[int, None]):
 def get_users_stats(api: XRayAPI):
     try:
         params = defaultdict(int)
-        for stat in filter(attrgetter('value'), api.get_users_stats(reset=True, timeout=30)):
+        for stat in filter(attrgetter('value'), api.get_users_stats(reset=False, timeout=30)):
             params[stat.name.split('.', 1)[0]] += stat.value
         params = list({"uid": uid, "value": value} for uid, value in params.items())
         return params
     except xray_exc.XrayError:
         return []
+
+
+def reset_users_stats(api: XRayAPI):
+    try:
+        api.get_users_stats(reset=True, timeout=30)
+    except xray_exc.XrayError:
+        pass
 
 
 def get_outbounds_stats(api: XRayAPI):
@@ -138,7 +145,12 @@ def record_user_usages():
 
     with ThreadPoolExecutor(max_workers=10) as executor:
         futures = {node_id: executor.submit(get_users_stats, api) for node_id, api in api_instances.items()}
-    api_params = {node_id: future.result() for node_id, future in futures.items()}
+    api_params = {}
+    for node_id, future in futures.items():
+        try:
+            api_params[node_id] = future.result()
+        except Exception:
+            api_params[node_id] = []
 
     users_usage = defaultdict(int)
     for node_id, params in api_params.items():
@@ -175,6 +187,12 @@ def record_user_usages():
                 where(Admin.id == bindparam('admin_id')). \
                 values(users_usage=Admin.users_usage + bindparam('value'))
             safe_execute(db, admin_update_stmt, admin_data)
+
+    # reset counters only after successful DB write
+    with ThreadPoolExecutor(max_workers=10) as executor:
+        for node_id, api in api_instances.items():
+            if api_params.get(node_id):
+                executor.submit(reset_users_stats, api)
 
     if DISABLE_RECORDING_NODE_USAGE:
         return

--- a/app/routers/core.py
+++ b/app/routers/core.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import os
 import time
 
 import commentjson
@@ -118,11 +119,13 @@ def modify_core_config(
         raise HTTPException(status_code=400, detail=str(err))
 
     xray.config = config
-    with open(XRAY_JSON, "w") as f:
+    tmp_path = XRAY_JSON + ".tmp"
+    with open(tmp_path, "w") as f:
         f.write(json.dumps(payload, indent=4))
 
     startup_config = xray.config.include_db_users()
     xray.core.restart(startup_config)
+    os.replace(tmp_path, XRAY_JSON)
     for node_id, node in list(xray.nodes.items()):
         if node.connected:
             xray.operations.restart_node(node_id, startup_config)

--- a/app/routers/node.py
+++ b/app/routers/node.py
@@ -103,7 +103,7 @@ async def node_logs(node_id: int, websocket: WebSocket, db: Session = Depends(ge
             interval = float(interval)
         except ValueError:
             return await websocket.close(reason="Invalid interval value", code=4400)
-        if interval > 10:
+        if interval <= 0 or interval > 10:
             return await websocket.close(
                 reason="Interval must be more than 0 and at most 10 seconds", code=4400
             )

--- a/app/routers/user.py
+++ b/app/routers/user.py
@@ -282,7 +282,7 @@ def active_next_plan(
     if (dbuser is None or dbuser.next_plan is None):
         raise HTTPException(
             status_code=404,
-            detail=f"User doesn't have next plan",
+            detail="User doesn't have next plan",
         )
 
     dbuser = crud.reset_user_by_next(db=db, dbuser=dbuser)

--- a/app/subscription/share.py
+++ b/app/subscription/share.py
@@ -286,9 +286,6 @@ def process_inbounds_and_tags(
                     salt = secrets.token_hex(8)
                     sni = random.choice(sni_list).replace("*", salt)
 
-                if sids := inbound.get("sids"):
-                    inbound["sid"] = random.choice(sids)
-
                 req_host = ""
                 req_host_list = host["host"] or inbound["host"]
                 if req_host_list:
@@ -324,6 +321,7 @@ def process_inbounds_and_tags(
                         "fragment_setting": host["fragment_setting"],
                         "noise_setting": host["noise_setting"],
                         "random_user_agent": host["random_user_agent"],
+                        "sid": random.choice(inbound["sids"]) if inbound.get("sids") else inbound.get("sid", ""),
                     }
                 )
 

--- a/app/subscription/singbox.py
+++ b/app/subscription/singbox.py
@@ -278,8 +278,7 @@ class SingBoxConfiguration(str):
         mux_config = mux_json["sing-box"]
 
         config['multiplex'] = mux_config
-        if config['multiplex']["enabled"]:
-            config['multiplex']["enabled"] = mux_enable
+        config['multiplex']["enabled"] = mux_enable
 
         return config
 

--- a/app/subscription/v2ray.py
+++ b/app/subscription/v2ray.py
@@ -261,7 +261,7 @@ class V2rayShareLink(str):
                 extra["xmux"] = xmux
             if downloadSettings:
                 extra["downloadSettings"] = downloadSettings
-            payload["type"] = mode
+            payload["mode"] = mode
             if extra:
                 payload["extra"] = (json.dumps(extra)).replace(" ", "")
 
@@ -655,6 +655,7 @@ class V2rayJsonConfig(str):
         if host:
             config["host"] = host
         if random_user_agent:
+            config.setdefault("headers", {})
             config["headers"]["User-Agent"] = choice(self.user_agent_list)
         extra = {}
         if sc_max_each_post_bytes is not None:
@@ -775,8 +776,8 @@ class V2rayJsonConfig(str):
         else:
             config["host"] = []
         if random_user_agent:
-            config["headers"]["User-Agent"] = [
-                choice(self.user_agent_list)]
+            config.setdefault("headers", {})
+            config["headers"]["User-Agent"] = [choice(self.user_agent_list)]
 
         return config
 
@@ -998,7 +999,7 @@ class V2rayJsonConfig(str):
         elif net == "kcp":
             network_setting = self.kcp_config(
                 seed=path, host=host, header=headers)
-        elif net in ("tcp", "raw") and tls != "reality":
+        elif net in ("tcp", "raw"):
             network_setting = self.tcp_config(
                 headers=headers, path=path, host=host, random_user_agent=random_user_agent)
         elif net == "quic":

--- a/app/xray/config.py
+++ b/app/xray/config.py
@@ -65,7 +65,6 @@ class XRayConfig(dict):
         api_inbound = self.get_inbound("API_INBOUND")
         if api_inbound:
             api_inbound["listen"] = self.api_host
-            api_inbound["listen"]["address"] = self.api_host
             api_inbound["port"] = self.api_port
             return
 

--- a/app/xray/core.py
+++ b/app/xray/core.py
@@ -19,7 +19,7 @@ class XRayCore:
 
         self.version = self.get_version()
         self.process = None
-        self.restarting = False
+        self._restart_lock = threading.Lock()
 
         self._logs_buffer = deque(maxlen=100)
         self._temp_log_buffers = {}
@@ -51,10 +51,10 @@ class XRayCore:
                 "public_key": public
             }
 
-    def __capture_process_logs(self):
+    def __capture_process_logs(self, proc):
         def capture_and_debug_log():
-            while self.process:
-                output = self.process.stdout.readline()
+            while proc.poll() is None:
+                output = proc.stdout.readline()
                 if output:
                     output = output.strip()
                     self._logs_buffer.append(output)
@@ -62,25 +62,19 @@ class XRayCore:
                         buf.append(output)
                     logger.debug(output)
 
-                elif not self.process or self.process.poll() is not None:
-                    break
-
         def capture_only():
-            while self.process:
-                output = self.process.stdout.readline()
+            while proc.poll() is None:
+                output = proc.stdout.readline()
                 if output:
                     output = output.strip()
                     self._logs_buffer.append(output)
                     for buf in list(self._temp_log_buffers.values()):
                         buf.append(output)
 
-                elif not self.process or self.process.poll() is not None:
-                    break
-
         if DEBUG:
-            threading.Thread(target=capture_and_debug_log).start()
+            threading.Thread(target=capture_and_debug_log, daemon=True).start()
         else:
-            threading.Thread(target=capture_only).start()
+            threading.Thread(target=capture_only, daemon=True).start()
 
     @contextmanager
     def get_logs(self):
@@ -129,7 +123,7 @@ class XRayCore:
         self.process.stdin.close()
         logger.warning(f"Xray core {self.version} started")
 
-        self.__capture_process_logs()
+        self.__capture_process_logs(self.process)
 
         # execute on start functions
         for func in self._on_start_funcs:
@@ -139,8 +133,13 @@ class XRayCore:
         if not self.started:
             return
 
-        self.process.terminate()
+        proc = self.process
         self.process = None
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except Exception:
+            proc.kill()
         logger.warning("Xray core stopped")
 
         # execute on stop functions
@@ -148,16 +147,15 @@ class XRayCore:
             threading.Thread(target=func).start()
 
     def restart(self, config: XRayConfig):
-        if self.restarting is True:
+        if not self._restart_lock.acquire(blocking=False):
             return
 
         try:
-            self.restarting = True
             logger.warning("Restarting Xray core...")
             self.stop()
             self.start(config)
         finally:
-            self.restarting = False
+            self._restart_lock.release()
 
     def on_start(self, func: callable):
         self._on_start_funcs.append(func)

--- a/app/xray/node.py
+++ b/app/xray/node.py
@@ -443,10 +443,22 @@ class RPyCXRayNode:
 
     def restart(self, config: XRayConfig):
         self.started = False
+        self._api = None
         config = self._prepare_config(config)
         json_config = config.to_json()
         self.remote.restart(json_config)
         self.started = True
+
+        self._api = XRayAPI(
+            address=self.address,
+            port=self.api_port,
+            ssl_cert=self._node_cert.encode(),
+            ssl_target_name="Gozargah"
+        )
+        try:
+            grpc.channel_ready_future(self._api._channel).result(timeout=5)
+        except grpc.FutureTimeoutError:
+            raise ConnectionError("Failed to reconnect to node's API after restart")
 
     @contextmanager
     def get_logs(self):

--- a/app/xray/operations.py
+++ b/app/xray/operations.py
@@ -1,3 +1,4 @@
+import threading
 from functools import lru_cache
 from typing import TYPE_CHECKING
 
@@ -87,7 +88,7 @@ def add_user(dbuser: "DBUser"):
             try:
                 proxy_settings = user.proxies[proxy_type].dict(no_obj=True)
             except KeyError:
-                pass
+                continue
             account = proxy_type.account_model(email=email, **proxy_settings)
 
             # XTLS currently only supports transmission methods of TCP and mKCP
@@ -133,15 +134,15 @@ def update_user(dbuser: "DBUser"):
             try:
                 proxy_settings = user.proxies[proxy_type].dict(no_obj=True)
             except KeyError:
-                pass
+                continue
             account = proxy_type.account_model(email=email, **proxy_settings)
 
             # XTLS currently only supports transmission methods of TCP and mKCP
             if getattr(account, 'flow', None) and (
-                inbound.get('network', 'tcp') not in ('tcp', 'kcp')
+                inbound.get('network', 'tcp') not in ('tcp', 'raw', 'kcp')
                 or
                 (
-                    inbound.get('network', 'tcp') in ('tcp', 'kcp')
+                    inbound.get('network', 'tcp') in ('tcp', 'raw', 'kcp')
                     and
                     inbound.get('tls') not in ('tls', 'reality')
                 )
@@ -208,21 +209,23 @@ def _change_node_status(node_id: int, status: NodeStatus, message: str = None, v
             db.rollback()
 
 
-global _connecting_nodes
-_connecting_nodes = {}
+_connecting_nodes: dict = {}
+_connecting_lock = threading.Lock()
 
 
 @threaded_function
 def connect_node(node_id, config=None):
-    global _connecting_nodes
-
-    if _connecting_nodes.get(node_id):
-        return
+    with _connecting_lock:
+        if _connecting_nodes.get(node_id):
+            return
+        _connecting_nodes[node_id] = True
 
     with GetDB() as db:
         dbnode = crud.get_node_by_id(db, node_id)
 
     if not dbnode:
+        with _connecting_lock:
+            _connecting_nodes.pop(node_id, None)
         return
 
     try:
@@ -232,7 +235,6 @@ def connect_node(node_id, config=None):
         node = xray.operations.add_node(dbnode)
 
     try:
-        _connecting_nodes[node_id] = True
 
         _change_node_status(node_id, NodeStatus.connecting)
         logger.info(f"Connecting to \"{dbnode.name}\" node")
@@ -250,10 +252,8 @@ def connect_node(node_id, config=None):
         logger.info(f"Unable to connect to \"{dbnode.name}\" node")
 
     finally:
-        try:
-            del _connecting_nodes[node_id]
-        except KeyError:
-            pass
+        with _connecting_lock:
+            _connecting_nodes.pop(node_id, None)
 
 
 @threaded_function

--- a/main.py
+++ b/main.py
@@ -125,7 +125,7 @@ Then, navigate to {click.style(f'http://{ip}:{UVICORN_PORT}', bold=True)} on you
 
     if DEBUG:
         bind_args['uds'] = None
-        bind_args['host'] = '0.0.0.0'
+        bind_args['host'] = '127.0.0.1'
 
     try:
         uvicorn.run(


### PR DESCRIPTION
## Summary

This PR fixes a set of correctness and concurrency bugs found while reviewing the xray lifecycle, subscription generation, usage accounting, and DB layer. Each change is small and self-contained.

## Critical

- **`app/xray/operations.py`** — `add_user`/`update_user`: the `except KeyError: pass` left `proxy_settings` undefined, so the next line raised `NameError` inside a daemon thread and silently dropped the user from xray. Changed to `continue`.
- **`app/xray/config.py`** — `_apply_api`: when the user config already contains an `API_INBOUND`, `api_inbound["listen"]["address"] = ...` does item-assignment on a `str` and raises `TypeError`, so xray never starts. Removed the offending line (`listen` is a plain IP string).
- **`app/db/crud.py`** — `get_all_users_usages`: passed an `Admin` ORM object to the `admins=` (List[str]) param, so `Admin.username.in_([<obj>])` matched nothing and the per-admin usage report always returned zero. Use `admin=`.
- **`app/jobs/record_usages.py`** — `get_users_stats(reset=True)` zeroed xray counters *before* the DB write; any DB failure permanently lost that traffic. Split fetch (`reset=False`) from reset, and only reset after a successful write. Also handle `future.result()` exceptions so one bad node doesn't abort the whole job.
- **`app/db/crud.py`** — `reset_user_by_next`: the remaining-traffic ternary was inverted (carry-over applied when `add_remaining_traffic` was **False**). Fixed.

## Thread-safety

- **`app/xray/core.py`** — replaced the unguarded `restarting` bool with a `threading.Lock` (`acquire(blocking=False)`); `stop()` now keeps a local process ref and `wait()`s (with `kill()` fallback) before clearing `self.process`, preventing zombies and double on_stop; log-capture thread receives the process by value and loops on `proc.poll()` instead of `self.process`.
- **`app/xray/operations.py`** — `_connecting_nodes` guard is now atomic under a `threading.Lock` (check+set in one critical section); previously two concurrent `connect_node` calls could both pass the guard and double-start a node.
- **`app/xray/node.py`** — `RPyCXRayNode.restart()` now recreates `self._api` and waits for the gRPC channel; previously it kept a stale channel to the dead process, so user add/remove after a restart silently failed (matches `ReSTXRayNode.restart()` / `start()`).

## Other correctness

- **`app/subscription/share.py`** — Reality `sid` is now written into the per-host `host_inbound` instead of mutating the shared `xray.config.inbounds_by_tag` dict (concurrent subscription requests could overwrite each other's short-id, yielding empty `shortId`).
- **`app/subscription/v2ray.py`** — vmess XHTTP set `payload["type"] = mode`, overwriting the header-type field; use `payload["mode"]` like grpc does. Also guard `config["headers"]` before writing `User-Agent` in `splithttp_config` (KeyError when settings lack `headers`), and drop the `and tls != "reality"` guard on the tcp branch so tcp+Reality stream settings aren't silently dropped.
- **`app/subscription/singbox.py`** — `multiplex.enabled` is now set unconditionally from `mux_enable`; previously it was only applied when the template default was already `true`, so enabling mux on a host had no effect.
- **`app/db/crud.py`** — `update_admin` checks `is_sudo is not None` so a sudo admin can actually be demoted (matches `partial_update_admin`).
- **`app/xray/operations.py`** — XTLS flow-stripping check now includes the `raw` network alias, matching `config.py`.
- **`main.py`** — `DEBUG=True` now binds `127.0.0.1` instead of `0.0.0.0`, so debug mode doesn't expose the admin API on all interfaces.
- **`app/routers/node.py`** — WebSocket log interval must be `> 0` (a `0` interval caused a tight busy-loop).
- **`app/routers/core.py`** — `PUT /core/config` writes to a temp file and `os.replace`s only after a successful restart, so a failed restart doesn't leave a broken config on disk.

## Testing

All changed files compile and pass `pyflakes` (no new undefined-name or unused-import warnings vs. the base). Changes are intentionally minimal and isolated per bug.