### PR TITLE
perf(db): add indexes on hot columns used by periodic jobs

### DIFF
--- a/app/db/migrations/versions/c5c2420d57bc_add_performance_indexes.py
+++ b/app/db/migrations/versions/c5c2420d57bc_add_performance_indexes.py
@@ -1,0 +1,53 @@
+"""add performance indexes
+
+Adds indexes on columns that are filtered on every periodic job and in
+per-user usage lookups, but were previously unindexed:
+
+- users.status      (review_users, reset_user_data_usage, autodelete, disable_all)
+- users.expire      (expiry checks)
+- users.admin_id    (filtering users by admin)
+- node_user_usages.user_id        (per-user traffic aggregation)
+- notification_reminders.user_id  (per-user reminder lookups in a tight loop)
+
+These are non-destructive CREATE INDEX operations and are safe to run with
+zero downtime on existing deployments.
+
+Revision ID: c5c2420d57bc
+Revises: 2b231de97dc3
+Create Date: 2026-06-11 17:10:00.000000
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = 'c5c2420d57bc'
+down_revision = '2b231de97dc3'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table('users') as batch_op:
+        batch_op.create_index('ix_users_status', ['status'])
+        batch_op.create_index('ix_users_expire', ['expire'])
+        batch_op.create_index('ix_users_admin_id', ['admin_id'])
+
+    with op.batch_alter_table('node_user_usages') as batch_op:
+        batch_op.create_index('ix_node_user_usages_user_id', ['user_id'])
+
+    with op.batch_alter_table('notification_reminders') as batch_op:
+        batch_op.create_index('ix_notification_reminders_user_id', ['user_id'])
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('notification_reminders') as batch_op:
+        batch_op.drop_index('ix_notification_reminders_user_id')
+
+    with op.batch_alter_table('node_user_usages') as batch_op:
+        batch_op.drop_index('ix_node_user_usages_user_id')
+
+    with op.batch_alter_table('users') as batch_op:
+        batch_op.drop_index('ix_users_admin_id')
+        batch_op.drop_index('ix_users_expire')
+        batch_op.drop_index('ix_users_status')

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -64,7 +64,7 @@ class User(Base):
     id = Column(Integer, primary_key=True)
     username = Column(String(34, collation='NOCASE'), unique=True, index=True)
     proxies = relationship("Proxy", back_populates="user", cascade="all, delete-orphan")
-    status = Column(Enum(UserStatus), nullable=False, default=UserStatus.active)
+    status = Column(Enum(UserStatus), nullable=False, default=UserStatus.active, index=True)
     used_traffic = Column(BigInteger, default=0)
     node_usages = relationship("NodeUserUsage", back_populates="user", cascade="all, delete-orphan")
     notification_reminders = relationship("NotificationReminder", back_populates="user", cascade="all, delete-orphan")
@@ -75,8 +75,8 @@ class User(Base):
         default=UserDataLimitResetStrategy.no_reset,
     )
     usage_logs = relationship("UserUsageResetLogs", back_populates="user")  # maybe rename it to reset_usage_logs?
-    expire = Column(Integer, nullable=True)
-    admin_id = Column(Integer, ForeignKey("admins.id"))
+    expire = Column(Integer, nullable=True, index=True)
+    admin_id = Column(Integer, ForeignKey("admins.id"), index=True)
     admin = relationship("Admin", back_populates="users")
     sub_revoked_at = Column(DateTime, nullable=True, default=None)
     sub_updated_at = Column(DateTime, nullable=True, default=None)
@@ -319,7 +319,7 @@ class NodeUserUsage(Base):
 
     id = Column(Integer, primary_key=True)
     created_at = Column(DateTime, unique=False, nullable=False)  # one hour per record
-    user_id = Column(Integer, ForeignKey("users.id"))
+    user_id = Column(Integer, ForeignKey("users.id"), index=True)
     user = relationship("User", back_populates="node_usages")
     node_id = Column(Integer, ForeignKey("nodes.id"))
     node = relationship("Node", back_populates="user_usages")
@@ -344,7 +344,7 @@ class NotificationReminder(Base):
     __tablename__ = "notification_reminders"
 
     id = Column(Integer, primary_key=True)
-    user_id = Column(Integer, ForeignKey("users.id"))
+    user_id = Column(Integer, ForeignKey("users.id"), index=True)
     user = relationship("User", back_populates="notification_reminders")
     type = Column(Enum(ReminderType), nullable=False)
     threshold = Column(Integer, nullable=True)


### PR DESCRIPTION
## Summary

Several columns are filtered on **every scheduler tick** or in per-user lookups, but have no index — so they trigger full table scans that get progressively worse as the user base grows.

This PR adds `index=True` on those columns plus a non-destructive Alembic migration.

## Columns indexed

| Column | Used by |
|--------|---------|
| `users.status` | `review_users`, `reset_user_data_usage`, `autodelete_expired_users`, `disable_all_active_users` |
| `users.expire` | expiry checks |
| `users.admin_id` | filtering users by admin |
| `node_user_usages.user_id` | per-user traffic aggregation in usage reports |
| `notification_reminders.user_id` | per-user reminder lookups (called in a tight loop in `add_notification_reminders`) |

## Notes

- The migration uses `batch_alter_table` + `create_index`, consistent with the existing migrations and SQLite-compatible.
- Index names follow SQLAlchemy's default `ix_<table>_<column>` convention, so the model definitions and the migration stay in sync (autogenerate won't see a diff).
- All `CREATE INDEX` operations are non-destructive and safe to apply with zero downtime.
- `down_revision` is set to the current single head `2b231de97dc3`.

## Testing

`app/db/models.py` and the new migration compile cleanly. Changes are additive only (no column/behavior changes).