### PR TITLE
fix(config): update fingerprint setting to use value from tls_settings

### DIFF
--- a/app/xray/config.py
+++ b/app/xray/config.py
@@ -213,7 +213,7 @@ class XRayConfig(dict):
                             settings['sni'].extend(get_cert_SANs(cert))
 
                 elif security == 'reality':
-                    settings['fp'] = 'chrome'
+                    settings['fp'] = tls_settings.get('fingerprint', 'chrome')
                     settings['tls'] = 'reality'
                     settings['sni'] = tls_settings.get('serverNames', [])
 


### PR DESCRIPTION
### Expected behavior

When `fingerprint` is explicitly set inside `realitySettings` of an inbound's `streamSettings` (e.g. `"fingerprint": "firefox"`), the generated subscription links for that inbound should use the same fingerprint (`fp=firefox`) instead of the default one.

### Actual behavior

Regardless of the `fingerprint` value set in `realitySettings`, the subscription page always returns `fp=chrome` for REALITY inbounds. It looks like the fingerprint from the xray config is simply not read — `chrome` is hardcoded as the value for every REALITY inbound.

Root cause found in `app/xray/config.py`, inside `XRayConfig._resolve_inbounds`:

```python
elif security == 'reality':
    settings['fp'] = 'chrome'   # <-- hardcoded, ignores tls_settings['fingerprint']
    settings['tls'] = 'reality'
    settings['sni'] = tls_settings.get('serverNames', [])
```

### Xray config (censored)

```json
{
  "log": {
    "loglevel": "debug"
  },
  "routing": {
    "rules": [
      {
        "ip": ["geoip:private"],
        "outboundTag": "BLOCK",
        "type": "field"
      }
    ]
  },
  "inbounds": [
    {
      "tag": "Shadowsocks TCP",
      "listen": "0.0.0.0",
      "port": 1080,
      "protocol": "shadowsocks",
      "settings": {
        "clients": [],
        "network": "tcp,udp"
      }
    },
    {
      "tag": "VLESS TCP REALITY",
      "listen": "0.0.0.0",
      "port": 8443,
      "protocol": "vless",
      "settings": {
        "clients": [],
        "decryption": "none"
      },
      "streamSettings": {
        "network": "tcp",
        "tcpSettings": {},
        "security": "reality",
        "realitySettings": {
          "show": false,
          "dest": "example.com:443",
          "xver": 0,
          "serverNames": ["example.com"],
          "privateKey": "<censored>",
          "fingerprint": "firefox",
          "shortIds": ["<censored>"]
        }
      },
      "sniffing": {
        "enabled": true,
        "destOverride": ["http", "tls", "quic"]
      }
    },
    {
      "tag": "VLESS XHTTP REALITY",
      "listen": "0.0.0.0",
      "port": 8444,
      "protocol": "vless",
      "settings": {
        "clients": [],
        "decryption": "none"
      },
      "streamSettings": {
        "network": "xhttp",
        "xhttpSettings": {
          "xPaddingBytes": "0",
          "host": "example.com",
          "mode": "auto"
        },
        "security": "reality",
        "realitySettings": {
          "show": false,
          "dest": "example.com:443",
          "xver": 0,
          "serverNames": ["example.com"],
          "privateKey": "<censored>",
          "SpiderX": "/",
          "fingerprint": "firefox",
          "shortIds": ["<censored>"]
        }
      },
      "sniffing": {
        "enabled": true,
        "destOverride": ["http", "tls", "quic"]
      }
    }
  ],
  "outbounds": [
    {
      "protocol": "freedom",
      "tag": "DIRECT"
    },
    {
      "protocol": "blackhole",
      "tag": "BLOCK"
    }
  ]
}
```

### Environment

- Marzban version: 0.8.4
- Xray-core version: v24.12.31
- Docker: yes, Docker version 29.3.1, build c2be9cc
- .env settings related to xray/docker: -
