### PR TITLE
feat(subscription): serve sing-box format for InHive client

### DIFF
--- a/app/routers/subscription.py
+++ b/app/routers/subscription.py
@@ -87,7 +87,7 @@ def user_subscription(
         conf = generate_subscription(user=user, config_format="clash", as_base64=False, reverse=False)
         return Response(content=conf, media_type="text/yaml", headers=response_headers)
 
-    elif re.match(r'^(SFA|SFI|SFM|SFT|[Kk]aring|[Hh]iddify[Nn]ext)|.*sing[-b]?ox.*', user_agent, re.IGNORECASE):
+    elif re.match(r'^(SFA|SFI|SFM|SFT|[Kk]aring|[Hh]iddify[Nn]ext|[Ii]n[Hh]ive)|.*sing[-b]?ox.*', user_agent, re.IGNORECASE):
         conf = generate_subscription(user=user, config_format="sing-box", as_base64=False, reverse=False)
         return Response(content=conf, media_type="application/json", headers=response_headers)
 


### PR DESCRIPTION
## What
Adds the InHive client to the sing-box User-Agent branch in `app/routers/subscription.py`:
```diff
- elif re.match(r'^(SFA|SFI|SFM|SFT|[Kk]aring|[Hh]iddify[Nn]ext)|.*sing[-b]?ox.*', user_agent, re.IGNORECASE):
+ elif re.match(r'^(SFA|SFI|SFM|SFT|[Kk]aring|[Hh]iddify[Nn]ext|[Ii]n[Hh]ive)|.*sing[-b]?ox.*', user_agent, re.IGNORECASE):
```

## Why
[InHive](https://inhive.ru) is a public sing-box-based VPN client (releases at [github.com/TwilgateLabs](https://github.com/TwilgateLabs): `inhive-android`, `inhive-windows`; iOS soon). UA: `InHive/<version> (<platform>; <hwid>)`. Its sing-box core supports hysteria2 / TUIC / Reality, so it should receive the sing-box JSON format.

Its UA matches none of the existing alternatives and contains no `singbox`/`sing-box` substring, so today it falls through to the v2ray/base64 path. Adding the `[Ii]n[Hh]ive` token routes it to `config_format="sing-box"`. Same one-line, no-config-flag shape as #881 (which added Karing/HiddifyNext). Verified the new regex matches `InHive/4.6.0 (android; ...)`.