### PR TITLE
feat(subscription): recognize InHive client → v2ray-json (full config)

### DIFF
--- a/app/routers/subscription.py
+++ b/app/routers/subscription.py
@@ -132,7 +132,12 @@ def user_subscription(
             conf = generate_subscription(user=user, config_format="v2ray", as_base64=True, reverse=False)
             return Response(content=conf, media_type="text/plain", headers=response_headers)
 
-
+    elif re.match(r'^InHive/', user_agent):
+        # InHive is a universal client (sing-box fork + Xray parity) that ingests
+        # Xray-JSON natively at any version, so it needs no custom-json flag or
+        # version gate — always serve the full structured v2ray-json config.
+        conf = generate_subscription(user=user, config_format="v2ray-json", as_base64=False, reverse=False)
+        return Response(content=conf, media_type="application/json", headers=response_headers)
 
     else:
         conf = generate_subscription(user=user, config_format="v2ray", as_base64=True, reverse=False)


### PR DESCRIPTION
Adds explicit recognition of the InHive client, serving it the structured `v2ray-json` format.

InHive is a universal client (a sing-box fork with Xray parity) whose parser ingests Xray-JSON natively. The `v2ray-json` generator (`V2rayJsonConfig`) carries the full transport set — ws/grpc/kcp/quic/httpupgrade/splithttp/**xhttp** + reality — with no stripping, which is what a universal client needs.

Unlike the `v2rayN`/`v2rayNG`/`Happ` branches, InHive needs **no** `USE_CUSTOM_JSON_*` flag or version gate: it supports Xray-JSON at every version, so the rule is unconditional.

## Change
- `app/routers/subscription.py`: add `elif re.match(r'^InHive/', user_agent)` → `config_format="v2ray-json"`, placed before the default `v2ray` base64 fallback.

## Notes
- No effect on any existing client — only adds a new UA match.
- InHive UA format: `InHive/<ver> (<platform>; <hwid>)`. Releases: github.com/TwilgateLabs.
- (This supersedes my earlier PR #2079, which incorrectly targeted the sing-box format — that generator drops xhttp/kcp.)