### PR TITLE
fix: parse x25519 output regardless of label format

### DIFF
--- a/app/xray/core.py
+++ b/app/xray/core.py
@@ -43,14 +43,23 @@ class XRayCore:
         if private_key:
             cmd.extend(['-i', private_key])
         output = subprocess.check_output(cmd, stderr=subprocess.STDOUT).decode('utf-8')
-        m = re.match(r'Private key: (.+)\nPublic key: (.+)', output)
-        if m:
-            private, public = m.groups()
+        kv = {}
+        for line in output.splitlines():
+            if ':' in line:
+                k, v = line.split(':', 1)
+                kv[k.strip().lower().replace(' ', '')] = v.strip()
+
+        def find(prefix):
+            for k, v in kv.items():
+                if k.startswith(prefix) and v:
+                    return v
+
+        public = find('publickey') or find('password')
+        if public:
             return {
-                "private_key": private,
+                "private_key": find('privatekey') or private_key,
                 "public_key": public
             }
-
     def __capture_process_logs(self):
         def capture_and_debug_log():
             while self.process:


### PR DESCRIPTION
Fixes #1938

## Problem

Xray changed the labels in `xray x25519` output more than once, and the parser in `app/xray/core.py` matches exact strings, so it returns `None` and config validation crashes.

Current output on my binary (v26.3.27):

```
PrivateKey: ...
Password (PublicKey): ...
Hash32: ...
```

The crash:

```
File "/code/app/routers/core.py", line 116, in modify_core_config
    config = XRayConfig(payload, api_port=xray.config.api_port)
File "/code/app/xray/config.py", line 60, in __init__
    self._resolve_inbounds()
File "/code/app/xray/config.py", line 231, in _resolve_inbounds
    settings['pbk'] = x25519['public_key']
TypeError: 'NoneType' object is not subscriptable
```

In the panel it shows up only as "Something went wrong, please check the configuration" when saving a REALITY inbound, so it is not obvious what actually failed. The same traceback is reported in #1938 by users on v25.8.31 and v25.10.15, where the only workarounds were adding `publicKey` to the config by hand or downgrading the core.

## Why prefix matching

The labels have already changed twice:

```
Private key: / Public key:            original
PrivateKey:  / Password:              v25.3.6+, handled by #1972
PrivateKey:  / Password (PublicKey):  current builds, not handled
```

Every fix so far pinned exact strings and broke on the next rename. This one parses the output as `key: value` lines and looks up the keys by prefix, so all three formats work and another label change will not break it again.

## Changes

`app/xray/core.py`, `get_x25519` only:

* output lines are parsed into a normalized key/value dict
* private key is taken from any key starting with `privatekey`, public key from `publickey` or `password`
* return shape stays `{"private_key": ..., "public_key": ...}`, so nothing else needs to change
* old format parses the same as before, so users on the bundled core see no difference

## Testing

Running in production on a Marzban master with nodes and a manually installed Xray v26.3.27 binary set through `XRAY_EXECUTABLE_PATH`. Before the patch, saving a VLESS + TCP + REALITY inbound failed with the traceback above. After the patch the config validates, `pbk` is generated correctly and clients connect through the nodes.

## Note

PR #2033 covers the `Password:` rename but targets `master` and includes unrelated changes, and it does not handle the `Password (PublicKey):` variant. This PR is a minimal single function change against `dev` as described in CONTRIBUTING.md.